### PR TITLE
feat: cross-platform release builds (Windows/macOS/Linux) + Windows chrome detection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,90 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build ${{ matrix.name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            targets: x86_64-unknown-linux-gnu
+            name: lightbrowse-linux-x86_64
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            targets: x86_64-pc-windows-msvc
+            name: lightbrowse-windows-x86_64.exe
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            targets: x86_64-apple-darwin aarch64-apple-darwin
+            name: lightbrowse-macos
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.targets }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      # macOS: build BOTH arches in one job (Xcode clang is universal).
+      - name: Build (macOS, x86_64 + aarch64)
+        if: runner.os == 'macOS'
+        run: |
+          cargo build --release --target x86_64-apple-darwin
+          cargo build --release --target aarch64-apple-darwin
+          mkdir -p dist
+          cp target/x86_64-apple-darwin/release/lightbrowse dist/lightbrowse-macos-x86_64
+          cp target/aarch64-apple-darwin/release/lightbrowse dist/lightbrowse-macos-aarch64
+
+      - name: Build (single target)
+        if: runner.os != 'macOS'
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Stage asset
+        if: runner.os != 'macOS'
+        shell: bash
+        run: |
+          mkdir -p dist
+          cp "target/${{ matrix.target }}/release/lightbrowse${{ runner.os == 'Windows' && '.exe' || '' }}" "dist/${{ matrix.name }}"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-${{ matrix.os }}
+          path: dist/
+          if-no-files-found: error
+
+  release:
+    name: Publish GitHub Release
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: List assets
+        run: ls -lh artifacts/
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: artifacts/*
+          generate_release_notes: true

--- a/crates/lightbrowse-cdp/src/lib.rs
+++ b/crates/lightbrowse-cdp/src/lib.rs
@@ -1044,21 +1044,54 @@ fn detect_chrome() -> Option<String> {
             return Some(p);
         }
     }
-    for name in [
-        "google-chrome",
-        "google-chrome-stable",
-        "chromium",
-        "chromium-browser",
-        "chrome",
-    ] {
-        if let Ok(out) = std::process::Command::new("which").arg(name).output() {
-            if out.status.success() {
-                if let Ok(s) = String::from_utf8(out.stdout) {
-                    let p = s.trim().to_string();
-                    if !p.is_empty() {
-                        return Some(p);
+    // Unix: look up browser names via `which`.
+    #[cfg(not(windows))]
+    {
+        for name in [
+            "google-chrome",
+            "google-chrome-stable",
+            "chromium",
+            "chromium-browser",
+            "chrome",
+        ] {
+            if let Ok(out) = std::process::Command::new("which").arg(name).output() {
+                if out.status.success() {
+                    if let Ok(s) = String::from_utf8(out.stdout) {
+                        let p = s.trim().to_string();
+                        if !p.is_empty() {
+                            return Some(p);
+                        }
                     }
                 }
+            }
+        }
+    }
+    // Windows: `where.exe` + well-known install paths (Chrome/Edge).
+    #[cfg(windows)]
+    {
+        for name in ["chrome", "msedge", "chromium"] {
+            if let Ok(out) = std::process::Command::new("where.exe").arg(name).output() {
+                if out.status.success() {
+                    if let Ok(s) = String::from_utf8(out.stdout) {
+                        let p = s.lines().next().unwrap_or("").trim().to_string();
+                        if !p.is_empty() {
+                            return Some(p);
+                        }
+                    }
+                }
+            }
+        }
+        let pf = std::env::var("ProgramFiles").unwrap_or_else(|_| "C:\\Program Files".to_string());
+        let pfx86 = std::env::var("ProgramFiles(x86)")
+            .unwrap_or_else(|_| "C:\\Program Files (x86)".to_string());
+        for p in [
+            format!("{pf}\\Google\\Chrome\\Application\\chrome.exe"),
+            format!("{pfx86}\\Google\\Chrome\\Application\\chrome.exe"),
+            format!("{pf}\\Microsoft\\Edge\\Application\\msedge.exe"),
+            format!("{pfx86}\\Microsoft\\Edge\\Application\\msedge.exe"),
+        ] {
+            if std::path::Path::new(&p).exists() {
+                return Some(p);
             }
         }
     }
@@ -1788,8 +1821,10 @@ mod tests {
 /// Integration test: CDP must self-heal when the Chromium process is killed
 /// mid-session (macOS report: "Trying to work with closed connection").
 /// Requires a Chrome/Chromium binary + network; runs in CI via --include-ignored.
+/// Uses unix-only `pkill`/`kill` — ignored on Windows.
 #[tokio::test]
 #[ignore = "requires Chrome + network"]
+#[cfg_attr(windows, ignore = "uses pkill/kill (unix-only)")]
 async fn recovers_after_chromium_killed() {
     let config = lightbrowse_core::config::Config {
         idle_timeout_secs: 300,


### PR DESCRIPTION
## What

Automated cross-platform release pipeline + the Windows fixes it needs:

1. **`.github/workflows/release.yml`** — build matrix: Linux x86_64, Windows x86_64, macOS x86_64 + aarch64 (both arches in one job, Xcode clang is universal). Artifacts upload to GitHub Releases on `v*` tags; `workflow_dispatch` for manual runs.
2. **`detect_chrome` Windows support** — `where.exe` lookup + well-known install paths (Chrome/Edge under `%ProgramFiles%`/`%ProgramFiles(x86)%`). `CHROME_PATH` env still takes priority. Fixes the `which`-on-Windows gap (issue #12).
3. **Test portability** — `recovers_after_chromium_killed` uses unix-only `pkill`/`kill`; now `#[cfg_attr(windows, ignore)]` so the suite runs on Windows.

## Verification

- `cargo check`/clippy clean (0 warnings), `cargo fmt --check` clean, workspace tests pass (14)
- YAML validated

Closes #12
