### PR TITLE
fix: idle-suspend race kills freshly-recovered Chromium + honor LIGHTBROWSE_IDLE_TIMEOUT

### DIFF
--- a/crates/lightbrowse-cdp/src/lib.rs
+++ b/crates/lightbrowse-cdp/src/lib.rs
@@ -174,7 +174,7 @@ impl CdpBackend {
                     .map(|g| g.elapsed())
                     .unwrap_or_default();
                 if idle_elapsed > Duration::from_secs(idle) {
-                    this.suspend().await;
+                    this.suspend(idle).await;
                 }
             }
         });
@@ -196,8 +196,23 @@ impl CdpBackend {
 
     /// Close Chromium gracefully (cookies flushed to the profile) and
     /// release its RAM. Called on idle timeout / shutdown.
-    pub async fn suspend(&self) {
+    ///
+    /// Re-checks `last_used` AFTER acquiring the browser lock: between the
+    /// watcher's idle check and this lock, an action may have touched the
+    /// backend or a fresh browser may have been spawned after a crash
+    /// recovery — we must never kill that one (observed race: tab created
+    /// 16:47:29 → suspended 16:47:31, i.e. a 1.8s-old browser killed).
+    pub async fn suspend(&self, idle_secs: u64) {
         let mut guard = self.inner.lock().await;
+        let still_idle = self
+            .last_used
+            .lock()
+            .map(|g| g.elapsed() > Duration::from_secs(idle_secs))
+            .unwrap_or(true);
+        if !still_idle {
+            tracing::debug!("cdp: idle suspend skipped — activity detected after check");
+            return;
+        }
         if let Some(b) = guard.take() {
             b.close_gracefully().await;
             self.tabs.lock().await.clear();
@@ -511,6 +526,11 @@ impl CdpBackend {
     /// returns that session's tab. Enforces the per-tab budget (max_tabs)
     /// with LRU eviction when the limit is hit.
     async fn ensure_page(&self, session_id: &str, url: &str) -> Result<ActivePage> {
+        // Mark activity immediately: a navigate/action is starting (or a
+        // crash-recovery is re-creating the tab). This makes the idle
+        // watcher's re-check in `suspend()` skip killing the browser we're
+        // about to use.
+        self.touch();
         // The browser struct may be alive while the process is actually dead
         // (crashed/killed) — detect zombies FIRST so we never reuse a dead
         // tab's websocket (macOS: 'Connection refused' / 'closed connection').

--- a/crates/lightbrowse-cli/src/main.rs
+++ b/crates/lightbrowse-cli/src/main.rs
@@ -197,9 +197,8 @@ async fn main() -> lightbrowse_core::Result<()> {
     {
         config.idle_timeout_secs = *t;
     }
-    if matches!(cli.cmd, Cmd::Serve { .. } | Cmd::Mcp { .. }) {
-        config.idle_timeout_secs = config.idle_timeout_secs.min(60);
-    }
+    // Note: an explicit --idle-timeout or LIGHTBROWSE_IDLE_TIMEOUT is honored
+    // as-is for serve/MCP too; the 60s default lives in Config::default().
 
     let fetch: Arc<dyn BrowserBackend> =
         Arc::new(FetchBackend::with_proxy(config.proxy.as_deref())?);


### PR DESCRIPTION
## What

Two bugs from the observed 16:47 sequence (tab created 16:47:29.965 → suspended 16:47:31, i.e. a **1.8s-old Chromium killed**):

**1. Idle-suspend race** — the idle watcher checks `last_used`, then `suspend()` waits for the browser lock. Between the check and the lock, a navigate / crash-recovery (`reset_browser` → spawn fresh) may have touched `last_used` or spawned a new Chromium — `suspend()` then killed that active browser with a "suspended" log 1.8s after its creation.
- Fix: `suspend(idle_secs)` **re-checks `last_used` after acquiring the lock** and skips the kill if activity happened.
- `touch()` added at the start of `ensure_page`, so any in-flight navigate/action marks activity immediately (closes the window where the retry is mid-flight without a touch).

**2. `LIGHTBROWSE_IDLE_TIMEOUT` silently capped to 60s** for serve/MCP (`config.idle_timeout_secs.min(60)` in main.rs) — an explicit 300 was ignored.
- Fix: honor the user's value. The 60s default lives in `Config::default()`, so behavior for users who don't set it is unchanged.

## Verification

- `LIGHTBROWSE_IDLE_TIMEOUT=300` → `/health` reports `idle_timeout: 300` (previously forced to 60).
- clippy/fmt clean, workspace tests pass.
