### PR TITLE
docs: SSO auth sharing across sessions — one Microsoft login works everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,21 @@ lightbrowse is built to get *past* login walls, not to fight CAPTCHAs:
    ```
    Chromium is closed with CDP `Browser.close` (not SIGKILL) so cookies are
    flushed to the profile.
+
+**SSO across sessions:** every CDP session (`?session=<id>` / `session:` arg)
+shares the SAME Chromium profile — one login works everywhere. Log into
+Microsoft SSO once and Outlook, Teams, SharePoint, Office apps are all
+auto-authenticated in any session, e.g. an enterprise setup:
+
+   ```bash
+   # session=office365: log in via CDP actions once
+   # session=outlook, session=teams, ...: already authenticated
+   ```
+
+   Caveats: (1) you MUST run with `--profile` (the default is a throwaway
+   stateless temp profile — no sharing, no persistence); (2) authenticated
+   sessions must use `engine=cdp` — the fetch engine has its own cookie
+   jars and cannot see Chromium cookies.
 2. **Stealth by default** — clean Chrome UA (no `HeadlessChrome`, no
    `lightbrowse/` marker), `navigator.webdriver` neutered, `window.chrome` /
    `plugins` / `languages` spoofed. Verified against bot.sannysoft.com.


### PR DESCRIPTION
Documents the shared-auth model: every CDP session uses the same persistent Chromium profile, so a single Microsoft SSO login (done once via CDP actions) auto-authenticates Outlook/Teams/SharePoint in any session. Notes the two caveats: --profile is required (default is a stateless throwaway), and authenticated sessions must use engine=cdp.