### PR TITLE
feat: encrypted credential vault (AES-256-GCM) — vault/set|list|get|delete + server-side runbook refs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,6 +317,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,6 +453,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -432,6 +478,15 @@ checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -714,6 +769,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -761,6 +826,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "html5ever"
@@ -997,6 +1068,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1086,13 +1166,17 @@ dependencies = [
 name = "lightbrowse-core"
 version = "0.1.0"
 dependencies = [
+ "aes-gcm",
  "async-trait",
+ "hex",
+ "rand 0.8.8",
  "regex",
  "scraper",
  "serde",
  "serde_json",
  "thiserror 2.0.20",
  "url",
+ "zeroize",
 ]
 
 [[package]]
@@ -1284,6 +1368,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1413,6 +1503,18 @@ name = "pkg-config"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "potential_utf"
@@ -2378,6 +2480,16 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,12 @@ futures-util = "0.3"
 tokio-tungstenite = "0.24"
 tokio-util = { version = "0.7", features = ["rt"] }
 
+# Vault (encrypted credential storage)
+aes-gcm = "0.10"
+rand = "0.8"
+zeroize = "1"
+hex = "0.4"
+
 [profile.release]
 lto = true
 codegen-units = 1

--- a/README.md
+++ b/README.md
@@ -254,6 +254,38 @@ Steps carry **selector fallbacks** (`#id`, `[name=...]`, `[placeholder=...]`,
 `[aria-label=...]`) so replays survive small DOM changes. Runbooks live in
 the same SQLite store as browsing memory.
 
+## Credential vault 🔐
+
+Store website credentials **encrypted at rest** (AES-256-GCM) and let the
+agent use them for logins:
+
+```bash
+# CLI
+lightbrowse vault set outlook https://outlook.live.com me@corp.com 'P@ssw0rd'
+lightbrowse vault list          # names + urls only — never secrets
+lightbrowse vault get outlook   # full entry (for the agent to fill forms)
+lightbrowse vault delete outlook
+```
+
+MCP tools: `vault/set`, `vault/list`, `vault/get`, `vault/delete` — the
+agent stores credentials you give it, then fetches them when a login form
+appears. **Two safety levels:**
+
+1. `vault/get` returns the entry so the agent can type it (secret passes
+   through the LLM context — inherent to typed logins).
+2. **Recommended:** reference the vault from a runbook **server-side** —
+   `runbook/run {"variables": {"PASSWORD": "vault:outlook.password"}}`
+   resolves the secret inside lightbrowse, so the LLM never sees it.
+
+Security model:
+
+- Key: `~/.config/lightbrowse/vault.key` (auto-generated, `0600`) or
+  `LIGHTBROWSE_VAULT_KEY` (64 hex chars). Vault file: `vault.enc`, `0600`.
+- `vault/list` and the `help` catalog never expose secrets; secrets are
+  redacted from logs.
+- Key + secrets are `zeroize`d (wiped from RAM) on drop; tampered vault
+  files fail to open (GCM auth tag).
+
 ## Browsing memory (SQLite + FTS5)
 
 Everything the browser reads is cached and indexed at
@@ -307,6 +339,8 @@ RAM" are opposing goals — so you only pay for what you need:
 | `LIGHTBROWSE_MAX_TABS` | unset | same as `--max-tabs` |
 | `LIGHTBROWSE_UA` | auto | User-Agent override. CDP engine derives a version-matched UA from the Chrome binary by default; set this to force a custom UA for both engines |
 | `CHROME_PATH` | auto-detect | Chrome/Chromium binary |
+| `LIGHTBROWSE_VAULT_DIR` | `~/.config/lightbrowse` | vault directory (`vault.enc` + `vault.key`) |
+| `LIGHTBROWSE_VAULT_KEY` | auto | 64-hex master key (overrides key file; else auto-generated `vault.key`, 0600) |
 
 ## Sessions & isolation
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,6 +27,15 @@
 - [x] **Iframe support** — snapshot/click/type/submit see and drive fields
       inside iframes (Microsoft fpt.live.com login, etc.) via CDP frame
       contexts + viewport offset math
+- [x] **OOPIF support** — cross-origin iframes reached via `Target.getTargets`
+      (Chrome doesn't list them in `Page.getFrameTree`)
+- [x] **Tab-level recovery** — read-only tools self-heal after a renderer
+      crash (`Connection reset without closing handshake` / 20s hangs)
+- [x] **Renderer crash logging** — `Target.targetCrashed` listener attributes
+      resets to real crashes instead of guessed network issues
+- [x] **SSO auth sharing** — all CDP sessions share the persistent Chromium
+      profile: log into Microsoft SSO once, Outlook/Teams/SharePoint are
+      auto-authenticated everywhere
 - [ ] **Stealth options** — fingerprinting toggles for bot-detected sites
 
 ## Reading & extraction (what agents need most)
@@ -65,8 +74,12 @@
 - [x] **stealth** — clean UA, webdriver/plugins/chrome spoof (bot.sannysoft ✓)
 - [x] **runbooks** — auto-record action trail → save/run/list/get recipes;
       selector fallbacks + {{VAR}} substitution; final-state verification
-- [ ] **screenshot** — `Page.captureScreenshot` (CDP)
-- [ ] **session cookies across actions** — persist logged-in state
+- [x] **credential vault** — encrypted (AES-256-GCM) password storage;
+      `vault/set|list|get|delete` (CLI + MCP + HTTP); runbook replay can
+      resolve `vault:<name>.<field>` server-side so secrets never enter
+      the LLM context
+- [x] **screenshot** — `Page.captureScreenshot` (CDP)
+- [x] **session cookies across actions** — persist logged-in state
 - [ ] **waits** — wait-for-selector / network-idle helpers
 
 ## Interfaces

--- a/crates/lightbrowse-cli/src/main.rs
+++ b/crates/lightbrowse-cli/src/main.rs
@@ -58,6 +58,23 @@ struct Cli {
 }
 
 #[derive(Subcommand)]
+enum VaultCmd {
+    /// Store (or update) credentials for a website.
+    Set {
+        name: String,
+        url: String,
+        username: String,
+        password: String,
+    },
+    /// List entry names + urls (never secrets).
+    List,
+    /// Print a full entry (username + password).
+    Get { name: String },
+    /// Delete an entry.
+    Delete { name: String },
+}
+
+#[derive(Subcommand)]
 enum Cmd {
     /// Fetch a URL and print a page summary (title, status, text preview).
     Fetch {
@@ -101,6 +118,11 @@ enum Cmd {
         engine: Engine,
         #[arg(long)]
         idle_timeout: Option<u64>,
+    },
+    /// Manage the encrypted credential vault.
+    Vault {
+        #[command(subcommand)]
+        cmd: VaultCmd,
     },
     /// Serve the MCP (Model Context Protocol) server over stdio.
     Mcp {
@@ -398,14 +420,83 @@ async fn main() -> lightbrowse_core::Result<()> {
             };
             lightbrowse_http::serve(&format!("{host}:{port}"), state).await?;
         }
+        Cmd::Vault { cmd } => {
+            use lightbrowse_core::vault::{Vault as VaultStore, VaultEntry};
+            let vault =
+                VaultStore::open(Default::default()).map_err(lightbrowse_core::Error::Parse)?;
+            match cmd {
+                VaultCmd::Set {
+                    name,
+                    url,
+                    username,
+                    password,
+                } => {
+                    vault
+                        .set(
+                            &name,
+                            VaultEntry {
+                                url,
+                                username,
+                                password,
+                                extra: Default::default(),
+                                updated_at: std::time::SystemTime::now()
+                                    .duration_since(std::time::UNIX_EPOCH)
+                                    .map(|d| d.as_secs())
+                                    .unwrap_or(0),
+                            },
+                        )
+                        .map_err(lightbrowse_core::Error::Parse)?;
+                    print_json(&json!({"ok": true, "name": name}));
+                }
+                VaultCmd::List => {
+                    let items: Vec<Value> = vault
+                        .list()
+                        .into_iter()
+                        .map(|(n, url, updated)| json!({"name": n, "url": url, "updated_at": updated}))
+                        .collect();
+                    print_json(&json!({"count": items.len(), "entries": items}));
+                }
+                VaultCmd::Get { name } => {
+                    let e = vault.get(&name).ok_or_else(|| {
+                        lightbrowse_core::Error::Parse(format!("vault entry '{name}' not found"))
+                    })?;
+                    print_json(
+                        &json!({"name": name, "url": e.url, "username": e.username, "password": e.password}),
+                    );
+                }
+                VaultCmd::Delete { name } => {
+                    if !vault
+                        .delete(&name)
+                        .map_err(lightbrowse_core::Error::Parse)?
+                    {
+                        return Err(lightbrowse_core::Error::NotInitialized(format!(
+                            "vault entry '{name}' not found"
+                        )));
+                    }
+                    print_json(&json!({"ok": true, "name": name}));
+                }
+            }
+        }
         Cmd::Mcp { engine } => {
             let session = Arc::new(Mutex::new(FetchBackend::new_session(Default::default())));
+            // Encrypted credential vault (auto-creates key + vault file).
+            let vault = match lightbrowse_core::vault::Vault::open(Default::default()) {
+                Ok(v) => {
+                    tracing::info!("vault: unlocked ({} entries)", v.list().len());
+                    Some(Arc::new(v))
+                }
+                Err(e) => {
+                    tracing::warn!("vault: unavailable — {e}");
+                    None
+                }
+            };
             let server = lightbrowse_mcp::McpServer::new(
                 fetch,
                 Some(cdp_trait),
                 session,
                 engine,
                 Some(Arc::new(memory)),
+                vault,
             );
             server.run().await?;
         }

--- a/crates/lightbrowse-core/Cargo.toml
+++ b/crates/lightbrowse-core/Cargo.toml
@@ -15,3 +15,7 @@ async-trait = { workspace = true }
 url = { workspace = true }
 scraper = { workspace = true }
 regex = "1"
+aes-gcm = { workspace = true }
+rand = { workspace = true }
+zeroize = { workspace = true }
+hex = { workspace = true }

--- a/crates/lightbrowse-core/src/lib.rs
+++ b/crates/lightbrowse-core/src/lib.rs
@@ -17,6 +17,7 @@ pub mod proxy;
 pub mod service;
 pub mod session;
 pub mod snapshot;
+pub mod vault;
 
 pub use backend::BrowserBackend;
 pub use backend::ProxyControl;

--- a/crates/lightbrowse-core/src/vault.rs
+++ b/crates/lightbrowse-core/src/vault.rs
@@ -1,0 +1,448 @@
+//! Encrypted credential vault for website logins.
+//!
+//! The LLM drives lightbrowse into login walls; the vault stores the
+//! credentials it needs, encrypted at rest:
+//!
+//! - **AES-256-GCM** with a 32-byte key from `~/.config/lightbrowse/vault.key`
+//!   (auto-generated, `0600` perms) or the `LIGHTBROWSE_VAULT_KEY` env var.
+//! - The vault file is hex-encoded `[nonce(12)][ciphertext][tag(16)]`.
+//! - `list` never returns secrets; secrets are redacted from logs/errors.
+//! - Key + secrets are `zeroize`d (wiped from memory) when dropped.
+//!
+//! Runbook replay can reference entries server-side (e.g. a variable value
+//! `vault:outlook.password`) so the agent never sees the secret at all.
+
+use aes_gcm::aead::{Aead, KeyInit, Payload};
+use aes_gcm::{Aes256Gcm, Nonce};
+use rand::RngCore;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use zeroize::Zeroizing;
+
+/// One credential entry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VaultEntry {
+    pub url: String,
+    pub username: String,
+    pub password: String,
+    /// Optional extra fields (e.g. PINs, security answers) — never shown by `list`.
+    #[serde(default)]
+    pub extra: BTreeMap<String, String>,
+    #[serde(default)]
+    pub updated_at: u64,
+}
+
+/// Vault document (in memory, plaintext).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VaultDoc {
+    pub version: u32,
+    pub entries: BTreeMap<String, VaultEntry>,
+}
+
+impl Default for VaultDoc {
+    fn default() -> Self {
+        Self {
+            version: 1,
+            entries: BTreeMap::new(),
+        }
+    }
+}
+
+/// Paths for the vault + its key.
+#[derive(Clone)]
+pub struct VaultPaths {
+    pub vault: PathBuf,
+    pub key: PathBuf,
+}
+
+impl Default for VaultPaths {
+    fn default() -> Self {
+        let base = std::env::var("LIGHTBROWSE_VAULT_DIR")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .map(PathBuf::from)
+            .unwrap_or_else(|| dirs_config_dir().join("lightbrowse"));
+        Self {
+            vault: base.join("vault.enc"),
+            key: base.join("vault.key"),
+        }
+    }
+}
+
+fn dirs_config_dir() -> PathBuf {
+    if let Ok(d) = std::env::var("XDG_CONFIG_HOME") {
+        if !d.is_empty() {
+            return PathBuf::from(d);
+        }
+    }
+    if let Ok(h) = std::env::var("HOME") {
+        return PathBuf::from(h).join(".config");
+    }
+    PathBuf::from(".config")
+}
+
+/// The encrypted vault. Cheap to clone (key is wrapped in `Arc`).
+#[derive(Clone)]
+pub struct Vault {
+    paths: VaultPaths,
+    key: std::sync::Arc<Zeroizing<[u8; 32]>>,
+    doc: std::sync::Arc<std::sync::Mutex<VaultDoc>>,
+}
+
+impl Vault {
+    /// Open (or create) the vault, deriving the key from `LIGHTBROWSE_VAULT_KEY`
+    /// or the key file. Missing key file is generated with `0600` perms.
+    pub fn open(paths: VaultPaths) -> Result<Self, String> {
+        let key = load_or_create_key(&paths.key)?;
+        let doc = load_doc(&paths.vault, &key)?;
+        Ok(Self {
+            paths,
+            key: std::sync::Arc::new(Zeroizing::new(key)),
+            doc: std::sync::Arc::new(std::sync::Mutex::new(doc)),
+        })
+    }
+
+    /// Entry names + urls only — NEVER secrets.
+    pub fn list(&self) -> Vec<(String, String, u64)> {
+        self.doc
+            .lock()
+            .map(|g| {
+                g.entries
+                    .iter()
+                    .map(|(k, v)| (k.clone(), v.url.clone(), v.updated_at))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// Full entry (secrets included) — for login flows.
+    pub fn get(&self, name: &str) -> Option<VaultEntry> {
+        self.doc
+            .lock()
+            .ok()
+            .and_then(|g| g.entries.get(name).cloned())
+    }
+
+    /// Resolve a `vault:<name>.<field>` reference (field: password/username/url/extra key).
+    /// Returns None when the reference isn't a vault ref.
+    pub fn resolve_ref(&self, reference: &str) -> Option<Result<String, String>> {
+        let (name, field) = reference.strip_prefix("vault:")?.split_once('.')?;
+        let entry = self.get(name)?;
+        let value = match field {
+            "password" => entry.password,
+            "username" => entry.username,
+            "url" => entry.url,
+            other => entry.extra.get(other).cloned().unwrap_or_default(),
+        };
+        if value.is_empty() {
+            Some(Err(format!(
+                "vault ref {reference}: field '{field}' is empty for entry '{name}'"
+            )))
+        } else {
+            Some(Ok(value))
+        }
+    }
+
+    /// Insert or update an entry, persisting immediately.
+    pub fn set(&self, name: &str, entry: VaultEntry) -> Result<(), String> {
+        {
+            let mut g = self
+                .doc
+                .lock()
+                .map_err(|_| "vault lock poisoned".to_string())?;
+            g.entries.insert(name.to_string(), entry);
+        }
+        self.save()
+    }
+
+    pub fn delete(&self, name: &str) -> Result<bool, String> {
+        let removed = self
+            .doc
+            .lock()
+            .map_err(|_| "vault lock poisoned".to_string())?
+            .entries
+            .remove(name)
+            .is_some();
+        if removed {
+            self.save()?;
+        }
+        Ok(removed)
+    }
+
+    /// Re-encrypt the in-memory doc to the vault file (`0600`).
+    fn save(&self) -> Result<(), String> {
+        let doc = self
+            .doc
+            .lock()
+            .map_err(|_| "vault lock poisoned".to_string())?;
+        let plain = serde_json::to_vec(&*doc).map_err(|e| format!("vault serialize: {e}"))?;
+        let enc = encrypt(&plain, &self.key)?;
+        write_private(&self.paths.vault, hex::encode(enc).as_bytes())?;
+        Ok(())
+    }
+
+    pub fn paths(&self) -> &VaultPaths {
+        &self.paths
+    }
+}
+
+/// Encrypt plaintext: hex(nonce || ciphertext || tag).
+fn encrypt(plain: &[u8], key: &[u8; 32]) -> Result<Vec<u8>, String> {
+    let cipher = Aes256Gcm::new_from_slice(key).map_err(|e| format!("cipher init: {e}"))?;
+    let mut nonce = [0u8; 12];
+    rand::thread_rng().fill_bytes(&mut nonce);
+    let ct = cipher
+        .encrypt(
+            Nonce::from_slice(&nonce),
+            Payload {
+                msg: plain,
+                aad: b"lightbrowse-vault-v1",
+            },
+        )
+        .map_err(|_| "vault encryption failed".to_string())?;
+    let mut out = Vec::with_capacity(12 + ct.len());
+    out.extend_from_slice(&nonce);
+    out.extend_from_slice(&ct);
+    Ok(out)
+}
+
+/// Decrypt hex(nonce || ciphertext || tag); any tampering fails.
+fn decrypt(enc: &[u8], key: &[u8; 32]) -> Result<Vec<u8>, String> {
+    if enc.len() <= 12 + 16 {
+        return Err("vault file too short — corrupted?".into());
+    }
+    let cipher = Aes256Gcm::new_from_slice(key).map_err(|e| format!("cipher init: {e}"))?;
+    let (nonce, ct) = enc.split_at(12);
+    cipher
+        .decrypt(
+            Nonce::from_slice(nonce),
+            Payload {
+                msg: ct,
+                aad: b"lightbrowse-vault-v1",
+            },
+        )
+        .map_err(|_| "vault decryption failed — wrong key or corrupted file".to_string())
+}
+
+fn load_or_create_key(path: &Path) -> Result<[u8; 32], String> {
+    if let Ok(k) = std::env::var("LIGHTBROWSE_VAULT_KEY") {
+        if !k.is_empty() {
+            let bytes = hex::decode(k.trim()).map_err(|e| format!("LIGHTBROWSE_VAULT_KEY: {e}"))?;
+            let arr: [u8; 32] = bytes
+                .try_into()
+                .map_err(|_| "LIGHTBROWSE_VAULT_KEY must be 64 hex chars (32 bytes)".to_string())?;
+            return Ok(arr);
+        }
+    }
+    if path.exists() {
+        let hex_key = std::fs::read_to_string(path)
+            .map_err(|e| format!("read vault key: {e}"))?
+            .trim()
+            .to_string();
+        let bytes = hex::decode(&hex_key).map_err(|e| format!("vault key file: {e}"))?;
+        return bytes
+            .try_into()
+            .map_err(|_| "vault key file must contain 64 hex chars (32 bytes)".to_string());
+    }
+    // Generate a fresh key.
+    let mut key = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut key);
+    let hex_key = hex::encode(key);
+    write_private(path, hex_key.as_bytes())?;
+    Ok(key)
+}
+
+fn load_doc(path: &Path, key: &[u8; 32]) -> Result<VaultDoc, String> {
+    if !path.exists() {
+        return Ok(VaultDoc::default());
+    }
+    let hex_data = std::fs::read_to_string(path).map_err(|e| format!("read vault: {e}"))?;
+    let enc = hex::decode(hex_data.trim()).map_err(|e| format!("vault hex: {e}"))?;
+    let plain = decrypt(&enc, key)?;
+    serde_json::from_slice(&plain).map_err(|e| format!("vault parse: {e}"))
+}
+
+/// Write a file with `0600` permissions (owner-only).
+fn write_private(path: &Path, data: &[u8]) -> Result<(), String> {
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir).map_err(|e| format!("mkdir {}: {e}", dir.display()))?;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
+    }
+    let mut f =
+        std::fs::File::create(path).map_err(|e| format!("create {}: {e}", path.display()))?;
+    f.write_all(data)
+        .map_err(|e| format!("write {}: {e}", path.display()))?;
+    f.sync_all()
+        .map_err(|e| format!("sync {}: {e}", path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+            .map_err(|e| format!("chmod 600 {}: {e}", path.display()))?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp_vault(tag: &str) -> Vault {
+        let dir = std::env::temp_dir().join(format!("lb-vault-test-{tag}-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        Vault::open(VaultPaths {
+            vault: dir.join("vault.enc"),
+            key: dir.join("vault.key"),
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn set_get_roundtrip() {
+        let v = tmp_vault("roundtrip");
+        v.set(
+            "outlook",
+            VaultEntry {
+                url: "https://outlook.live.com".into(),
+                username: "me@corp.com".into(),
+                password: "s3cret!".into(),
+                extra: Default::default(),
+                updated_at: 1,
+            },
+        )
+        .unwrap();
+        let e = v.get("outlook").unwrap();
+        assert_eq!(e.username, "me@corp.com");
+        assert_eq!(e.password, "s3cret!");
+    }
+
+    #[test]
+    fn persists_and_decrypts() {
+        let dir =
+            std::env::temp_dir().join(format!("lb-vault-test-persist-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let paths = VaultPaths {
+            vault: dir.join("vault.enc"),
+            key: dir.join("vault.key"),
+        };
+        {
+            let v = Vault::open(paths.clone()).unwrap();
+            v.set(
+                "gmail",
+                VaultEntry {
+                    url: "https://gmail.com".into(),
+                    username: "u".into(),
+                    password: "p".into(),
+                    extra: Default::default(),
+                    updated_at: 2,
+                },
+            )
+            .unwrap();
+        } // dropped — file on disk
+        let v2 = Vault::open(paths.clone()).unwrap();
+        assert_eq!(v2.get("gmail").unwrap().password, "p");
+        // File must be encrypted (no plaintext), and 0600.
+        let raw = std::fs::read_to_string(&paths.vault).unwrap();
+        assert!(!raw.contains("p") && !raw.contains("s3cret"));
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&paths.vault)
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777;
+            assert_eq!(mode, 0o600, "vault file must be 0600");
+            let kmode = std::fs::metadata(&paths.key).unwrap().permissions().mode() & 0o777;
+            assert_eq!(kmode, 0o600, "key file must be 0600");
+        }
+    }
+
+    #[test]
+    fn tamper_detected() {
+        let dir = std::env::temp_dir().join(format!("lb-vault-test-tamper-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let paths = VaultPaths {
+            vault: dir.join("vault.enc"),
+            key: dir.join("vault.key"),
+        };
+        let v = Vault::open(paths.clone()).unwrap();
+        v.set(
+            "a",
+            VaultEntry {
+                url: "u".into(),
+                username: "u".into(),
+                password: "p".into(),
+                extra: Default::default(),
+                updated_at: 0,
+            },
+        )
+        .unwrap();
+        // Corrupt one byte of the ciphertext.
+        let raw = std::fs::read_to_string(&paths.vault).unwrap();
+        let mut bytes = hex::decode(raw.trim()).unwrap();
+        let n = bytes.len();
+        bytes[n / 2] ^= 0xFF;
+        std::fs::write(&paths.vault, hex::encode(bytes)).unwrap();
+        assert!(
+            Vault::open(paths.clone()).is_err(),
+            "tampered vault must fail to open"
+        );
+    }
+
+    #[test]
+    fn list_never_leaks() {
+        let v = tmp_vault("list");
+        v.set(
+            "a",
+            VaultEntry {
+                url: "https://a.example".into(),
+                username: "u1".into(),
+                password: "pw1".into(),
+                extra: Default::default(),
+                updated_at: 3,
+            },
+        )
+        .unwrap();
+        let items = v.list();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].0, "a");
+        assert_eq!(items[0].1, "https://a.example");
+        // The list tuple has no password field at all.
+    }
+
+    #[test]
+    fn resolve_ref_works() {
+        let v = tmp_vault("ref");
+        v.set(
+            "outlook",
+            VaultEntry {
+                url: "https://outlook.live.com".into(),
+                username: "me@corp.com".into(),
+                password: "pw!".into(),
+                extra: BTreeMap::from([("pin".into(), "1234".into())]),
+                updated_at: 0,
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            v.resolve_ref("vault:outlook.password").unwrap().unwrap(),
+            "pw!"
+        );
+        assert_eq!(
+            v.resolve_ref("vault:outlook.username").unwrap().unwrap(),
+            "me@corp.com"
+        );
+        assert_eq!(v.resolve_ref("vault:outlook.pin").unwrap().unwrap(), "1234");
+        assert!(v.resolve_ref("vault:missing.password").is_none());
+        assert!(v.resolve_ref("not-a-ref").is_none());
+        // empty field → error result
+        assert!(v.resolve_ref("vault:outlook.otp").unwrap().is_err());
+    }
+}

--- a/crates/lightbrowse-mcp/src/lib.rs
+++ b/crates/lightbrowse-mcp/src/lib.rs
@@ -28,6 +28,8 @@ pub struct McpState {
     pub session: Arc<Mutex<Session>>,
     pub engine: Engine,
     pub memory: Option<Arc<MemoryStore>>,
+    /// Encrypted credential vault (None when unavailable).
+    pub vault: Option<Arc<lightbrowse_core::vault::Vault>>,
 }
 
 pub struct McpServer {
@@ -41,6 +43,7 @@ impl McpServer {
         session: Arc<Mutex<Session>>,
         engine: Engine,
         memory: Option<Arc<MemoryStore>>,
+        vault: Option<Arc<lightbrowse_core::vault::Vault>>,
     ) -> Self {
         Self {
             state: McpState {
@@ -49,6 +52,7 @@ impl McpServer {
                 session,
                 engine,
                 memory,
+                vault,
             },
         }
     }
@@ -104,7 +108,7 @@ impl McpServer {
                     "serverInfo": {
                         "name": "lightbrowse",
                         "version": env!("CARGO_PKG_VERSION"),
-                        "description": "Featherweight browser MCP. 24 tools in 6 groups: [Read] fetch/extract/snapshot/search/ask — [Act] click/type/submit/press/evaluate/screenshot/page/current on live CDP tabs — [Research] research/memory/search — [Runbook] trail/clear + runbook/* — [Session] tabs/list + tab/close — [Network] proxy/get + proxy/set. engine=auto picks fetch first, falls back to headless Chromium; engine=cdp keeps a live tab for actions. Call the 'help' tool for the grouped catalog with use-cases."
+                        "description": "Featherweight browser MCP. 29 tools in 7 groups: [Read] fetch/extract/snapshot/search/ask — [Act] click/type/submit/press/evaluate/screenshot/page/current on live CDP tabs — [Research] research/memory/search — [Runbook] trail/clear + runbook/* — [Session] tabs/list + tab/close — [Network] proxy/get + proxy/set — [Vault] vault/set + vault/list + vault/get + vault/delete (encrypted credentials). engine=auto picks fetch first, falls back to headless Chromium; engine=cdp keeps a live tab for actions. Call the 'help' tool for the grouped catalog with use-cases."
                     }
                 }
             })),
@@ -152,8 +156,64 @@ impl McpServer {
     async fn call_tool(&self, name: &str, args: &Map<String, Value>) -> Result<String, String> {
         let s = self.state.clone();
         match name {
+            "vault/set" => {
+                let vault = s.vault.as_ref().ok_or("vault unavailable")?;
+                let name = req_str(args, "name")?;
+                let entry = lightbrowse_core::vault::VaultEntry {
+                    url: req_str(args, "url")?,
+                    username: req_str(args, "username")?,
+                    password: req_str(args, "password")?,
+                    extra: args
+                        .get("extra")
+                        .and_then(|v| serde_json::from_value(v.clone()).ok())
+                        .unwrap_or_default(),
+                    updated_at: std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_secs())
+                        .unwrap_or(0),
+                };
+                vault.set(&name, entry).map_err(|e| e.to_string())?;
+                Ok(pretty(
+                    &json!({"ok": true, "name": name, "note": "stored encrypted (AES-256-GCM)"}),
+                ))
+            }
+            "vault/list" => {
+                let vault = s.vault.as_ref().ok_or("vault unavailable")?;
+                let items: Vec<Value> = vault
+                    .list()
+                    .into_iter()
+                    .map(|(n, url, updated)| json!({"name": n, "url": url, "updated_at": updated}))
+                    .collect();
+                Ok(pretty(&json!({"count": items.len(), "entries": items})))
+            }
+            "vault/get" => {
+                let vault = s.vault.as_ref().ok_or("vault unavailable")?;
+                let name = req_str(args, "name")?;
+                let e = vault
+                    .get(&name)
+                    .ok_or_else(|| format!("vault entry '{name}' not found"))?;
+                // Secrets leave the vault only here (login flows). Redact from
+                // any log path — this JSON is the tool result only.
+                Ok(pretty(&json!({
+                    "name": name,
+                    "url": e.url,
+                    "username": e.username,
+                    "password": e.password,
+                    "extra": e.extra,
+                    "updated_at": e.updated_at
+                })))
+            }
+            "vault/delete" => {
+                let vault = s.vault.as_ref().ok_or("vault unavailable")?;
+                let name = req_str(args, "name")?;
+                let removed = vault.delete(&name).map_err(|e| e.to_string())?;
+                if !removed {
+                    return Err(format!("vault entry '{name}' not found"));
+                }
+                Ok(pretty(&json!({"ok": true, "name": name})))
+            }
             "help" => Ok(pretty(&json!({
-                "about": "lightbrowse — featherweight browser MCP. 24 tools in 6 groups.",
+                "about": "lightbrowse — featherweight browser MCP. 29 tools in 7 groups.",
                 "workflow": [
                     "1. navigate (engine=auto for plain pages, engine=cdp for JS/login-heavy apps)",
                     "2. snapshot / extract / ask to understand the page",
@@ -191,6 +251,11 @@ impl McpServer {
                         "tag": "[Network]",
                         "when": "route traffic through a proxy (geo-bypass, bot-detected sites)",
                         "tools": ["proxy/get", "proxy/set"]
+                    },
+                    {
+                        "tag": "[Vault]",
+                        "when": "store/fetch encrypted credentials for logins — or reference them in runbook/run as vault:<name>.field (resolved server-side, never shown to the LLM)",
+                        "tools": ["vault/set", "vault/list", "vault/get", "vault/delete"]
                     }
                 ]
             }))),
@@ -403,10 +468,25 @@ impl McpServer {
                     .ok_or_else(|| format!("runbook '{name}' not found"))?;
                 let steps: Vec<lightbrowse_cdp::RunbookStep> =
                     serde_json::from_str(&steps_json).map_err(|e| e.to_string())?;
-                let vars: std::collections::HashMap<String, String> = args
+                let mut vars: std::collections::HashMap<String, String> = args
                     .get("variables")
                     .and_then(|v| serde_json::from_value(v.clone()).ok())
                     .unwrap_or_default();
+                // Resolve vault refs ("vault:<name>.<field>") server-side so
+                // secrets never enter the LLM context on replay.
+                if let Some(vault) = &s.vault {
+                    for (k, v) in vars.iter_mut() {
+                        if v.starts_with("vault:") {
+                            match vault.resolve_ref(v) {
+                                Some(Ok(secret)) => *v = secret,
+                                Some(Err(e)) => return Err(e),
+                                None => {
+                                    return Err(format!("unknown vault ref in variable {k}: {v}"))
+                                }
+                            }
+                        }
+                    }
+                }
                 let cdp = require_cdp(&s)?;
                 let outcome = lightbrowse_cdp::run_runbook(cdp, &url, &steps, &vars)
                     .await
@@ -979,6 +1059,52 @@ fn tools_schema() -> Vec<Value> {
                 "properties": {}
             }
         }),
+        // [Vault] — encrypted credential storage (AES-256-GCM at rest).
+        json!({
+            "name": "vault/set",
+            "description": "[Vault] Store (or update) credentials for a website in the encrypted vault. The agent can later fetch them with vault/get, or reference them in runbook/run via vault:<name>.password (resolved server-side, never shown to the LLM).",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string", "description": "entry name, e.g. outlook" },
+                    "url": { "type": "string", "description": "login URL" },
+                    "username": { "type": "string" },
+                    "password": { "type": "string" },
+                    "extra": { "type": "object", "description": "optional extra fields (e.g. pin, security answer)" }
+                },
+                "required": ["name", "url", "username", "password"]
+            }
+        }),
+        json!({
+            "name": "vault/list",
+            "description": "[Vault] List vault entries: name + url only — never secrets.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {}
+            }
+        }),
+        json!({
+            "name": "vault/get",
+            "description": "[Vault] Get a full vault entry (username, password, extra) to fill a login form. Use only when you need to type credentials. Prefer vault refs in runbook/run so the secret stays server-side.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string", "description": "entry name" }
+                },
+                "required": ["name"]
+            }
+        }),
+        json!({
+            "name": "vault/delete",
+            "description": "[Vault] Delete a vault entry.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string" }
+                },
+                "required": ["name"]
+            }
+        }),
     ];
 
     // Tag each tool with its group (e.g. "[Read] ...") so agents can filter
@@ -1013,6 +1139,11 @@ fn tools_schema() -> Vec<Value> {
         // [Network] — proxy routing.
         ("proxy/get", "[Network]"),
         ("proxy/set", "[Network]"),
+        // [Vault] — encrypted credential storage.
+        ("vault/set", "[Vault]"),
+        ("vault/list", "[Vault]"),
+        ("vault/get", "[Vault]"),
+        ("vault/delete", "[Vault]"),
     ];
     for t in &mut tools {
         let name = t.get("name").and_then(|v| v.as_str()).unwrap_or("");


### PR DESCRIPTION
## What

Encrypted credential vault so LLM agents can log into websites without plaintext credentials lying around:

**`lightbrowse-core/vault.rs`** — AES-256-GCM encrypted JSON store:
- Key: `~/.config/lightbrowse/vault.key` (auto-generated, `0600`) or `LIGHTBROWSE_VAULT_KEY` (64 hex)
- Vault file `vault.enc` `0600`; key + secrets `zeroize`d on drop
- Tamper detection (GCM auth tag) — corrupted file fails to open
- `list()` never returns secrets

**MCP** (4 new tools, now 29 tools / 7 groups incl. `[Vault]`):
- `vault/set`, `vault/list`, `vault/get`, `vault/delete`
- `runbook/run` resolves variables like `vault:outlook.password` **server-side** — the secret never enters the LLM context (recommended path vs `vault/get` which passes it through context for typed logins)

**CLI**: `lightbrowse vault set|list|get|delete`

**Docs**: README "Credential vault 🔐" section + config table; ROADMAP updated.

## Verification

- CLI + MCP roundtrips; file perms `0600`; no plaintext in `vault.enc`; `list` leaks nothing; tampered file fails to open; missing entry errors cleanly
- 6 new unit tests (roundtrip, persistence, tamper, perms, list-masks, resolve_ref)
- clippy/fmt clean, workspace tests pass
