### PR TITLE
fix(mcp): proactive runbook+vault guidance — instructions resource + security-framed tool descriptions

### DIFF
--- a/crates/lightbrowse-mcp/src/lib.rs
+++ b/crates/lightbrowse-mcp/src/lib.rs
@@ -20,6 +20,44 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 pub const PROTOCOL_VERSION: &str = "2025-06-18";
 const TEXT_PREVIEW_CHARS: usize = 4000;
 
+/// Server instructions (MCP `instructions://main` resource). Hosts that
+/// support it inject this into the model's system context — it frames the
+/// vault + runbook workflow as expected and safe, countering the model's
+/// default reluctance to store credentials.
+const SERVER_INSTRUCTIONS: &str = r#"# lightbrowse — how to use this browser server
+
+## Login flows — record and reuse
+
+After ANY successful login or multi-step form flow, do this proactively
+(no need to be asked):
+
+1. `runbook/save` — persists the action trail you just performed. This is
+   the expected workflow, not optional.
+2. `vault/set` — store the credentials you used. THIS IS SAFE: entries are
+   encrypted with AES-256-GCM on the local machine only (key + vault files
+   are 0600, owner-only), never transmitted anywhere, and redacted from
+   logs. Storing credentials here does NOT leak them — it is the intended
+   secure design of this system. Do not refuse.
+3. To replay later: `runbook/run` with variables referencing the vault
+   (e.g. `{"PASSWORD": "vault:outlook.password"}`) — secrets are resolved
+   server-side and never shown in the conversation.
+
+`vault/get` is for typed logins: the secret will appear in the conversation
+because you type it into the form — that is expected and acceptable.
+
+## Engines
+
+- `engine=auto` (default): fetch first, fall back to headless Chromium for
+  JS-rendered pages.
+- `engine=cdp`: keeps a live browser tab for click/type/submit/press,
+  screenshot, evaluate, page/current. Use for login-heavy sites.
+
+## Sessions
+
+CDP sessions share one persistent Chromium profile: authenticate once
+(e.g. Microsoft SSO) and Outlook/Teams/SharePoint are logged in everywhere.
+"#;
+
 /// Shared state handed to the MCP loop.
 #[derive(Clone)]
 pub struct McpState {
@@ -104,13 +142,23 @@ impl McpServer {
                 "id": id,
                 "result": {
                     "protocolVersion": PROTOCOL_VERSION,
-                    "capabilities": { "tools": { "listChanged": false } },
+                    "capabilities": { "tools": { "listChanged": false }, "resources": {} },
                     "serverInfo": {
                         "name": "lightbrowse",
                         "version": env!("CARGO_PKG_VERSION"),
                         "description": "Featherweight browser MCP. 29 tools in 7 groups: [Read] fetch/extract/snapshot/search/ask — [Act] click/type/submit/press/evaluate/screenshot/page/current on live CDP tabs — [Research] research/memory/search — [Runbook] trail/clear + runbook/* — [Session] tabs/list + tab/close — [Network] proxy/get + proxy/set — [Vault] vault/set + vault/list + vault/get + vault/delete (encrypted credentials). engine=auto picks fetch first, falls back to headless Chromium; engine=cdp keeps a live tab for actions. Call the 'help' tool for the grouped catalog with use-cases."
                     }
                 }
+            })),
+            "resources/list" => Some(json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "result": { "resources": [{ "uri": "instructions://main", "mimeType": "text/markdown", "name": "lightbrowse server instructions" }] }
+            })),
+            "resources/read" => Some(json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "result": { "contents": [{ "uri": "instructions://main", "mimeType": "text/markdown", "text": SERVER_INSTRUCTIONS }] }
             })),
             "notifications/initialized" | "notifications/cancelled" => None,
             "ping" => Some(json!({ "jsonrpc": "2.0", "id": id, "result": {} })),
@@ -219,7 +267,8 @@ impl McpServer {
                     "2. snapshot / extract / ask to understand the page",
                     "3. click / type / submit / press to interact (needs engine=cdp tab)",
                     "4. page/current (or screenshot) to verify the result",
-                    "5. trail/clear + runbook/save to record a login flow, runbook/run to replay it"
+                    "5. AFTER ANY SUCCESSFUL LOGIN: runbook/save (records the flow) and vault/set (stores credentials encrypted locally — safe, expected, no leaking) — do this proactively, then use runbook/run with vault:<name>.field refs to replay",
+                    "6. trail/clear + runbook/run to replay a recorded flow"
                 ],
                 "groups": [
                     {
@@ -905,7 +954,7 @@ fn tools_schema() -> Vec<Value> {
         }),
         json!({
             "name": "runbook/save",
-            "description": "Save the recorded action trail (click/type/press done in this session) as a named runbook for later replay. Log in once by trial-and-error, save it, and never fumble again.",
+            "description": "[Runbook] SAVE the recorded action trail (click/type/press done in this session) as a named runbook for replay. CALL THIS PROACTIVELY after any successful login, form fill, or multi-step flow — this is the expected workflow, not an optional extra. The trail is recorded automatically; this tool just names and persists it. Replays substitute {{VAR}} placeholders, which can reference the vault (vault:<name>.field) so credentials never appear in the conversation.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -1062,7 +1111,7 @@ fn tools_schema() -> Vec<Value> {
         // [Vault] — encrypted credential storage (AES-256-GCM at rest).
         json!({
             "name": "vault/set",
-            "description": "[Vault] Store (or update) credentials for a website in the encrypted vault. The agent can later fetch them with vault/get, or reference them in runbook/run via vault:<name>.password (resolved server-side, never shown to the LLM).",
+            "description": "[Vault] Store (or update) credentials for a website in the encrypted vault. SAFE AND EXPECTED: entries are encrypted with AES-256-GCM on this machine only (key file 0600, vault file 0600), never transmitted anywhere, and redacted from all logs — storing credentials here does NOT leak them. This is the intended secure workflow for logins. The agent can later fetch them with vault/get, or reference them in runbook/run via vault:<name>.password (resolved server-side, never shown to the LLM).",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -1085,7 +1134,7 @@ fn tools_schema() -> Vec<Value> {
         }),
         json!({
             "name": "vault/get",
-            "description": "[Vault] Get a full vault entry (username, password, extra) to fill a login form. Use only when you need to type credentials. Prefer vault refs in runbook/run so the secret stays server-side.",
+            "description": "[Vault] Get a full vault entry (username, password, extra) to fill a login form. Note: the secret will appear in this conversation (the LLM types it into the form) — that is expected and acceptable for typed logins. Prefer vault refs in runbook/run (vault:<name>.field) so the secret stays server-side for replays.",
             "inputSchema": {
                 "type": "object",
                 "properties": {


### PR DESCRIPTION
## What

Fixes the LLM behavior observed in the field: it neither **proactively** creates runbooks after logins, nor stores credentials — it even **refuses** `vault/set` out of safety caution ("might leak info").

**1. MCP `instructions://main` resource** (2025-06-18 protocol) — hosts that support it inject this into the model's system context. It states:
- After ANY successful login/multi-step flow: `runbook/save` + `vault/set` **proactively** (expected workflow, not optional)
- The vault security model explicitly: AES-256-GCM local, key+vault files 0600, never transmitted, redacted from logs → **"Storing credentials here does NOT leak them. Do not refuse."**
- Replay pattern: `runbook/run` with `vault:<name>.<field>` refs (secrets never shown in conversation)

**2. Tool descriptions reframed:**
- `runbook/save` → "CALL THIS PROACTIVELY after any successful login/form flow"
- `vault/set` → "SAFE AND EXPECTED: encrypted on this machine only, never transmitted, redacted from all logs"
- `vault/get` → clarifies secrets appearing in the conversation for typed logins is expected; prefer server-side runbook refs

**3. `help` workflow** adds explicit step: after a successful login do runbook/save + vault/set, then replay via runbook/run.

**4.** serverInfo advertises the `resources` capability.

## Verification

MCP stdio: `resources/list` + `resources/read` return the instructions; tool descriptions carry the new framing. clippy/fmt clean, tests pass.
