### PR TITLE
fix: sync workspace version + VaultEntry.extra arbitrary nested JSON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "lightbrowse"
-version = "0.1.0"
+version = "0.3.2"
 dependencies = [
  "clap",
  "lightbrowse-cdp",
@@ -1147,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "lightbrowse-cdp"
-version = "0.1.0"
+version = "0.3.2"
 dependencies = [
  "async-trait",
  "base64",
@@ -1164,7 +1164,7 @@ dependencies = [
 
 [[package]]
 name = "lightbrowse-core"
-version = "0.1.0"
+version = "0.3.2"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -1181,7 +1181,7 @@ dependencies = [
 
 [[package]]
 name = "lightbrowse-fetch"
-version = "0.1.0"
+version = "0.3.2"
 dependencies = [
  "async-trait",
  "lightbrowse-core",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "lightbrowse-http"
-version = "0.1.0"
+version = "0.3.2"
 dependencies = [
  "axum",
  "lightbrowse-cdp",
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "lightbrowse-mcp"
-version = "0.1.0"
+version = "0.3.2"
 dependencies = [
  "lightbrowse-cdp",
  "lightbrowse-core",
@@ -1224,7 +1224,7 @@ dependencies = [
 
 [[package]]
 name = "lightbrowse-memory"
-version = "0.1.0"
+version = "0.3.2"
 dependencies = [
  "lightbrowse-core",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.3.2"
 edition = "2021"
 license = "MIT"
 authors = ["maphim"]

--- a/crates/lightbrowse-core/src/vault.rs
+++ b/crates/lightbrowse-core/src/vault.rs
@@ -27,9 +27,11 @@ pub struct VaultEntry {
     pub url: String,
     pub username: String,
     pub password: String,
-    /// Optional extra fields (e.g. PINs, security answers) — never shown by `list`.
+    /// Optional extra fields — arbitrary JSON (nested objects, arrays, e.g.
+    /// {pin, answers: [...]}). Never shown by `list`. Old string-map entries
+    /// still deserialize (serde_json::Value is a superset).
     #[serde(default)]
-    pub extra: BTreeMap<String, String>,
+    pub extra: serde_json::Value,
     #[serde(default)]
     pub updated_at: u64,
 }
@@ -134,7 +136,46 @@ impl Vault {
             "password" => entry.password,
             "username" => entry.username,
             "url" => entry.url,
-            other => entry.extra.get(other).cloned().unwrap_or_default(),
+            other => {
+                // Nested path into `extra` JSON: answers.0, server.host, ...
+                let mut cur = &entry.extra;
+                let mut ok = true;
+                for part in other.split('.') {
+                    cur = match cur {
+                        serde_json::Value::Object(m) => match m.get(part) {
+                            Some(v) => v,
+                            None => {
+                                ok = false;
+                                break;
+                            }
+                        },
+                        serde_json::Value::Array(a) => {
+                            match part.parse::<usize>().ok().and_then(|i| a.get(i)) {
+                                Some(v) => v,
+                                None => {
+                                    ok = false;
+                                    break;
+                                }
+                            }
+                        }
+                        _ => {
+                            ok = false;
+                            break;
+                        }
+                    };
+                }
+                if !ok {
+                    return Some(Err(format!(
+                        "vault ref {reference}: field '{field}' not found for entry '{name}'"
+                    )));
+                }
+                match cur {
+                    serde_json::Value::String(s) => s.clone(),
+                    serde_json::Value::Number(n) => n.to_string(),
+                    serde_json::Value::Bool(b) => b.to_string(),
+                    _ => String::new(), // object/array/null — not directly usable
+                }
+            }
         };
         if value.is_empty() {
             Some(Err(format!(
@@ -426,7 +467,7 @@ mod tests {
                 url: "https://outlook.live.com".into(),
                 username: "me@corp.com".into(),
                 password: "pw!".into(),
-                extra: BTreeMap::from([("pin".into(), "1234".into())]),
+                extra: serde_json::json!({ "pin": "1234", "answers": ["a", "b"] }),
                 updated_at: 0,
             },
         )
@@ -440,6 +481,11 @@ mod tests {
             "me@corp.com"
         );
         assert_eq!(v.resolve_ref("vault:outlook.pin").unwrap().unwrap(), "1234");
+        // nested JSON refs work too
+        assert_eq!(
+            v.resolve_ref("vault:outlook.answers.0").unwrap().unwrap(),
+            "a"
+        );
         assert!(v.resolve_ref("vault:missing.password").is_none());
         assert!(v.resolve_ref("not-a-ref").is_none());
         // empty field → error result

--- a/crates/lightbrowse-mcp/src/lib.rs
+++ b/crates/lightbrowse-mcp/src/lib.rs
@@ -1119,7 +1119,7 @@ fn tools_schema() -> Vec<Value> {
                     "url": { "type": "string", "description": "login URL" },
                     "username": { "type": "string" },
                     "password": { "type": "string" },
-                    "extra": { "type": "object", "description": "optional extra fields (e.g. pin, security answer)" }
+                    "extra": { "type": "object", "description": "optional extra fields — arbitrary nested JSON (e.g. {\"pin\": 1234, \"answers\": [\"a\"]}), referenced in runbook/run as vault:<name>.pin or vault:<name>.answers.0" }
                 },
                 "required": ["name", "url", "username", "password"]
             }


### PR DESCRIPTION
## What

Addresses Kiro's v0.3.2 review (fair, actionable):

**1. Version sync** — `serverInfo.version` (and `lightbrowse --version`) reported **0.1.0** because the workspace `Cargo.toml` version was never bumped, while releases were tagged v0.3.x. Now `0.3.2` everywhere.

**2. `VaultEntry.extra` → arbitrary nested JSON** — was `BTreeMap<String, String>`; now `serde_json::Value`:
- Store nested structures: `{"pin": 1234, "server": {"host": "mail.corp"}, "answers": ["a","b"]}`
- `resolve_ref` walks dotted paths: `vault:corp.server.host`, `vault:corp.answers.0` (numbers/bools → strings)
- Old string-map entries still deserialize; missing fields → clear error
- Verified over MCP: set + get roundtrip with nested JSON

**3. Chaos-verified crash recovery** — 3 extra SIGKILL → restart → navigate cycles: **200 every time** (worst case ~22s on the first call after a crash; the spawn-retry from #22 covers the transient profile/port contention).

19/19 tests pass (incl. new nested-extra test), clippy/fmt clean.
