### PR TITLE
feat: vision-grounded perception — SoM visual_snapshot + click_at + bbox + Gemini Web vision sidecar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .idea/
 .vscode/
 .codegraph/
+.gemini-vision.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
+]
+
+[[package]]
 name = "alloc-no-stdlib"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,6 +149,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
+name = "arg_enum_proc_macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
+name = "as-slice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,6 +214,55 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "av-scenechange"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
+dependencies = [
+ "aligned",
+ "anyhow",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "log",
+ "num-rational",
+ "num-traits",
+ "pastey",
+ "rayon",
+ "thiserror 2.0.20",
+ "v_frame",
+ "y4m",
+]
+
+[[package]]
+name = "av1-grain"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "log",
+ "nom",
+ "num-rational",
+ "v_frame",
+]
+
+[[package]]
+name = "avif-serialize"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7178fe5f7d460b13895ebb9dcb28a3a6216d2df2574a0806cb51b555d297f38"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "axum"
@@ -230,10 +335,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bit_field"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
+
+[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
+name = "bitstream-io"
+version = "4.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
+dependencies = [
+ "no_std_io2",
+]
 
 [[package]]
 name = "block-buffer"
@@ -266,16 +386,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "built"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -290,6 +428,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -365,6 +505,12 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "colorchoice"
@@ -445,6 +591,37 @@ checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -564,12 +741,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12a0bb14ac04a9fcf170d0bbbef949b44cc492f4452bd20c095636956f653642"
 
 [[package]]
+name = "either"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -589,6 +792,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "exr"
+version = "1.74.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711fe42c9964295e01ee3fba3f9fe0e1d24b98886950d68efe81b1c76e21adf3"
+dependencies = [
+ "bit_field",
+ "half",
+ "lebe",
+ "miniz_oxide",
+ "num-complex",
+ "pulp",
+ "rayon-core",
+ "smallvec",
+ "zune-inflate",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -599,6 +819,21 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -779,6 +1014,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -795,6 +1040,17 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1058,6 +1314,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "color_quant",
+ "exr",
+ "gif",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png",
+ "qoi",
+ "ravif",
+ "rayon",
+ "rgb",
+ "tiff",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
+name = "imgref"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e44b0a4eaa4c82f441d50a963f2d5f05a787240aeee097597033e72accfd22f"
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1077,6 +1373,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "interpolate_name"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1089,10 +1396,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -1112,10 +1438,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lebe"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
+
+[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9fd2f41a1cba099f79a0b6b6c35656cf7c03351a7bae8ff0f28f25270f929d2"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -1169,6 +1517,7 @@ dependencies = [
  "aes-gcm",
  "async-trait",
  "hex",
+ "image",
  "rand 0.8.8",
  "regex",
  "scraper",
@@ -1198,6 +1547,7 @@ name = "lightbrowse-http"
 version = "0.4.0"
 dependencies = [
  "axum",
+ "base64",
  "lightbrowse-cdp",
  "lightbrowse-core",
  "lightbrowse-fetch",
@@ -1212,6 +1562,7 @@ dependencies = [
 name = "lightbrowse-mcp"
 version = "0.4.0"
 dependencies = [
+ "base64",
  "lightbrowse-cdp",
  "lightbrowse-core",
  "lightbrowse-fetch",
@@ -1261,6 +1612,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
+name = "loop9"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
+dependencies = [
+ "imgref",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1302,6 +1662,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if",
+ "rayon",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1335,10 +1705,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "no_std_io2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "nu-ansi-term"
@@ -1350,10 +1754,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "bytemuck",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "once_cell"
@@ -1395,6 +1859,18 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "percent-encoding"
@@ -1505,6 +1981,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1556,6 +2045,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "profiling"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "psl-types"
 version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1570,6 +2078,50 @@ dependencies = [
  "idna",
  "psl-types",
 ]
+
+[[package]]
+name = "pulp"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046aa45b989642ec2e4717c8e72d677b13edd831a4d3b6cf37d9a3e54912496a"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "libm",
+ "num-complex",
+ "paste",
+ "pulp-wasm-simd-flag",
+ "raw-cpuid",
+ "reborrow",
+ "version_check",
+]
+
+[[package]]
+name = "pulp-wasm-simd-flag"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d8f70e07b9c3962945a74e59ca1c511bba65b6419468acc217c457d93f3c740"
+
+[[package]]
+name = "pxfm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
+
+[[package]]
+name = "qoi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quinn"
@@ -1655,8 +2207,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1681,12 +2243,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1703,6 +2284,91 @@ checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
  "rand_core 0.10.1",
 ]
+
+[[package]]
+name = "rav1e"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
+dependencies = [
+ "aligned-vec",
+ "arbitrary",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "av-scenechange",
+ "av1-grain",
+ "bitstream-io",
+ "built",
+ "cfg-if",
+ "interpolate_name",
+ "itertools",
+ "libc",
+ "libfuzzer-sys",
+ "log",
+ "maybe-rayon",
+ "new_debug_unreachable",
+ "noop_proc_macro",
+ "num-derive",
+ "num-traits",
+ "paste",
+ "profiling",
+ "rand 0.9.5",
+ "rand_chacha 0.9.0",
+ "simd_helpers",
+ "thiserror 2.0.20",
+ "v_frame",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ravif"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e52310197d971b0f5be7fe6b57530dcd27beb35c1b013f29d66c1ad73fbbcc45"
+dependencies = [
+ "avif-serialize",
+ "imgref",
+ "loop9",
+ "quick-error",
+ "rav1e",
+ "rayon",
+ "rgb",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "reborrow"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
 
 [[package]]
 name = "redox_syscall"
@@ -1787,6 +2453,12 @@ dependencies = [
  "web-sys",
  "webpki-roots",
 ]
+
+[[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 
 [[package]]
 name = "ring"
@@ -2028,6 +2700,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
+name = "simd_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
+dependencies = [
+ "quote",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2204,6 +2885,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -2528,6 +3223,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "v_frame"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
+dependencies = [
+ "aligned-vec",
+ "num-traits",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2667,6 +3373,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2765,6 +3477,12 @@ name = "writeable"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
+
+[[package]]
+name = "y4m"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
 
 [[package]]
 name = "yoke"
@@ -2874,3 +3592,27 @@ name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zune-core"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56377fd46368984a170bc5aac5567e52ca5da874caa60bea39fcbca78fb658b"
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]

--- a/crates/lightbrowse-cdp/src/lib.rs
+++ b/crates/lightbrowse-cdp/src/lib.rs
@@ -1061,6 +1061,80 @@ impl CdpBackend {
         Ok(json!({ "ok": true, "tag": tag, "x": x.round() as u64, "y": y.round() as u64 }))
     }
 
+    /// Click at raw viewport coordinates (CSS px, top-left origin) — the
+    /// "human pointing" action for SoM/vision agents. Dispatches a real
+    /// mouseMoved → pressed → released sequence at the given point.
+    pub async fn click_at(&self, x: f64, y: f64, session: Option<&str>) -> Result<Value> {
+        let (sid, active) = self.active_page(session).await?;
+        if x < 0.0 || y < 0.0 {
+            return Ok(json!({ "ok": false, "reason": "coordinates must be >= 0" }));
+        }
+        let (mut ws, _) = tokio_tungstenite::connect_async(&active.ws_url)
+            .await
+            .map_err(|e| Error::Transport(format!("cdp connect: {e}")))?;
+        let (rx, ry) = (x.round() as u64, y.round() as u64);
+        for (typ, buttons) in [("mouseMoved", 0), ("mousePressed", 1), ("mouseReleased", 0)] {
+            rpc_expect(
+                &mut ws,
+                "Input.dispatchMouseEvent",
+                json!({
+                    "type": typ,
+                    "x": rx,
+                    "y": ry,
+                    "button": "left",
+                    "buttons": buttons,
+                    "clickCount": 1
+                }),
+            )
+            .await?;
+        }
+        let _ = ws.close(None).await;
+        self.touch();
+        self.touch_tab(&sid).await;
+        Ok(json!({ "ok": true, "x": rx, "y": ry }))
+    }
+
+    /// Get viewport bounding boxes for a batch of CSS selectors in ONE JS
+    /// pass. Returns a map {selector: [x, y, w, h]} for elements that are
+    /// visible and non-zero-sized. Selectors are top-document paths (the
+    /// same ones the snapshot tree emits).
+    pub async fn element_rects(
+        &self,
+        selectors: &[String],
+        session: Option<&str>,
+    ) -> Result<std::collections::HashMap<String, [f64; 4]>> {
+        if selectors.is_empty() {
+            return Ok(std::collections::HashMap::new());
+        }
+        let list = serde_json::to_string(selectors)
+            .map_err(|e| Error::Parse(format!("element_rects encode: {e}")))?;
+        let expr = format!(
+            "(() => {{ const sels = {list}; const out = {{}}; \
+             for (const s of sels) {{ \
+               const el = document.querySelector(s); if (!el) continue; \
+               const r = el.getBoundingClientRect(); \
+               if (r.width < 1 || r.height < 1) continue; \
+               const cs = getComputedStyle(el); \
+               if (cs.visibility === 'hidden' || cs.display === 'none') continue; \
+               out[s] = [Math.round(r.x), Math.round(r.y), Math.round(r.width), Math.round(r.height)]; \
+             }} \
+             return out; }})()"
+        );
+        let v = self.evaluate(&expr, session).await?;
+        let mut out = std::collections::HashMap::new();
+        if let Some(obj) = v.as_object() {
+            for (sel, arr) in obj {
+                if let Some(a) = arr.as_array() {
+                    let vals: Vec<f64> = a.iter().filter_map(|x| x.as_f64()).collect();
+                    if vals.len() == 4 {
+                        out.insert(sel.clone(), [vals[0], vals[1], vals[2], vals[3]]);
+                    }
+                }
+            }
+        }
+        Ok(out)
+    }
+
     /// Type text like a real keyboard (CDP `Input.insertText` — fires genuine
     /// input events; React and anti-bot both see a human typing).
     pub async fn type_text(

--- a/crates/lightbrowse-cli/src/main.rs
+++ b/crates/lightbrowse-cli/src/main.rs
@@ -116,6 +116,31 @@ enum Cmd {
         #[arg(long, default_value = "auto", value_parser = parse_engine)]
         engine: Engine,
     },
+    /// Human-like look: screenshot the ACTIVE tab with numbered SoM frames
+    /// over interactive elements + a number→uid map. Vision LLMs pick numbers;
+    /// non-vision LLMs can still act from the map JSON.
+    VisualSnapshot {
+        /// Optional URL — when given, navigates first (engine=cdp). When
+        /// omitted, looks at the current active tab.
+        url: Option<String>,
+        #[arg(long, default_value_t = 40)]
+        max_marks: usize,
+        #[arg(long, default_value_t = 400)]
+        max_nodes: usize,
+        #[arg(long, default_value = "visual-snapshot.png")]
+        output: String,
+        /// Settle wait (ms) after navigate before looking — lets bot
+        /// challenges / heavy JS finish. Default 3000.
+        #[arg(long, default_value_t = 3000)]
+        settle_ms: u64,
+    },
+    /// Click at raw viewport coordinates (CSS px) — pairs with visual-snapshot.
+    ClickAt {
+        x: f64,
+        y: f64,
+        #[arg(long)]
+        session: Option<String>,
+    },
     /// Web search via DuckDuckGo (no API key).
     Search {
         query: String,
@@ -340,6 +365,77 @@ async fn main() -> lightbrowse_core::Result<()> {
             };
             let tree = snapshot::snapshot(&page.html, &page.url, &opts);
             print_json(&serde_json::to_value(tree).unwrap());
+        }
+        Cmd::VisualSnapshot {
+            url,
+            max_marks,
+            max_nodes,
+            output,
+            settle_ms,
+        } => {
+            if let Some(u) = url {
+                // Live tab needed — bypass the memory cache so the CDP
+                // backend actually registers the tab.
+                lightbrowse_core::service::navigate(
+                    &*fetch,
+                    Some(&*cdp_trait),
+                    &session,
+                    &u,
+                    Engine::Cdp,
+                )
+                .await?;
+                if settle_ms > 0 {
+                    tokio::time::sleep(std::time::Duration::from_millis(settle_ms)).await;
+                }
+            }
+            let (html, title, url) = cdp.current_dom(None).await?;
+            let opts = SnapshotOptions {
+                max_nodes: max_nodes.clamp(10, 2000),
+                max_depth: 12,
+                ..SnapshotOptions::default()
+            };
+            let mut tree = snapshot::snapshot(&html, &url, &opts);
+            let sels = snapshot::collect_selectors(&tree);
+            let rects = cdp.element_rects(&sels, None).await?;
+            snapshot::attach_rects(&mut tree, &rects);
+
+            let shot = std::env::temp_dir().join(format!("lb-shot-{}.png", std::process::id()));
+            let shot_path = cdp.screenshot(&shot, false, None).await?;
+            let png = std::fs::read(&shot_path)?;
+            let marks = lightbrowse_core::vision::select_marks(&tree, max_marks.clamp(1, 200));
+            let som_marks: Vec<lightbrowse_core::vision::Mark> = marks
+                .iter()
+                .map(|(label, _, _, b)| lightbrowse_core::vision::Mark {
+                    label: *label,
+                    bbox: *b,
+                })
+                .collect();
+            let overlaid = lightbrowse_core::vision::overlay(&png, &som_marks)?;
+            std::fs::write(&output, &overlaid)?;
+
+            let mut map = serde_json::Map::new();
+            for (label, uid, text, bbox) in &marks {
+                map.insert(
+                    label.to_string(),
+                    json!({
+                        "uid": uid,
+                        "text": text,
+                        "bbox": [bbox.x, bbox.y, bbox.w, bbox.h]
+                    }),
+                );
+            }
+            print_json(&json!({
+                "url": url,
+                "title": title,
+                "count": marks.len(),
+                "overlay": output,
+                "map": map,
+                "note": "Open the overlay image, pick the number that matches your goal, then: lightbrowse click-at <x> <y>"
+            }));
+        }
+        Cmd::ClickAt { x, y, session } => {
+            let res = cdp.click_at(x, y, session.as_deref()).await?;
+            print_json(&res);
         }
         Cmd::Search { query, max_results } => {
             let ddg = format!(

--- a/crates/lightbrowse-core/Cargo.toml
+++ b/crates/lightbrowse-core/Cargo.toml
@@ -19,3 +19,4 @@ aes-gcm = { workspace = true }
 rand = { workspace = true }
 zeroize = { workspace = true }
 hex = { workspace = true }
+image = "0.25"

--- a/crates/lightbrowse-core/src/lib.rs
+++ b/crates/lightbrowse-core/src/lib.rs
@@ -18,6 +18,7 @@ pub mod service;
 pub mod session;
 pub mod snapshot;
 pub mod vault;
+pub mod vision;
 
 pub use backend::BrowserBackend;
 pub use backend::ProxyControl;

--- a/crates/lightbrowse-core/src/snapshot.rs
+++ b/crates/lightbrowse-core/src/snapshot.rs
@@ -5,10 +5,23 @@
 //! and visible text — each with a stable `uid` so the agent can refer to
 //! elements across calls (e.g. "click uid 42").
 
+use std::collections::HashMap;
+
 use scraper::{ElementRef, Html, Node, Selector};
 use serde::Serialize;
 
 use crate::extract::is_visible;
+
+/// Viewport-relative bounding box (CSS px, top-left origin) of a snapshot
+/// node. Populated only when a live renderer (CDP) can provide layout info;
+/// the pure-fetch engine omits it.
+#[derive(Debug, Clone, Copy, Serialize)]
+pub struct Bbox {
+    pub x: f64,
+    pub y: f64,
+    pub w: f64,
+    pub h: f64,
+}
 
 #[derive(Debug, Clone, Copy)]
 pub struct SnapshotOptions {
@@ -53,6 +66,9 @@ pub struct SnapshotNode {
     /// node (click/type/submit) via `document.querySelector`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub selector: Option<String>,
+    /// Viewport bounding box (CDP engine only; `None` on fetch).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bbox: Option<Bbox>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub children: Vec<SnapshotNode>,
 }
@@ -290,6 +306,7 @@ fn build_node(elm: &ElementRef, ctx: &mut Ctx, depth: usize) -> Option<SnapshotN
         alt: e.attr("alt").map(|s| s.to_string()),
         level: heading_level(tag),
         selector: Some(css_path(elm)),
+        bbox: None,
         children: collect_children(elm, ctx, depth),
     };
 
@@ -319,6 +336,7 @@ fn collect_children_only(elm: &ElementRef, ctx: &mut Ctx, depth: usize) -> Optio
             alt: None,
             level: None,
             selector: None,
+            bbox: None,
             children,
         })
     }
@@ -336,6 +354,54 @@ fn collect_children(elm: &ElementRef, ctx: &mut Ctx, depth: usize) -> Vec<Snapsh
         }
     }
     out
+}
+
+/// Attach viewport bounding boxes (keyed by CSS selector) to a snapshot tree.
+/// Non-matching selectors keep `bbox: None`. Purely additive.
+pub fn attach_rects(tree: &mut SnapshotTree, rects: &HashMap<String, [f64; 4]>) {
+    fn walk(n: &mut SnapshotNode, rects: &HashMap<String, [f64; 4]>) {
+        if let Some(sel) = &n.selector {
+            if let Some(r) = rects.get(sel) {
+                n.bbox = Some(Bbox {
+                    x: r[0],
+                    y: r[1],
+                    w: r[2],
+                    h: r[3],
+                });
+            }
+        }
+        for c in &mut n.children {
+            walk(c, rects);
+        }
+    }
+    for n in &mut tree.nodes {
+        walk(n, rects);
+    }
+}
+
+/// Collect every CSS selector in the tree (breadth-first, stable order).
+pub fn collect_selectors(tree: &SnapshotTree) -> Vec<String> {
+    fn walk(n: &SnapshotNode, acc: &mut Vec<String>) {
+        if let Some(s) = &n.selector {
+            acc.push(s.clone());
+        }
+        for c in &n.children {
+            walk(c, acc);
+        }
+    }
+    let mut out = Vec::new();
+    for n in &tree.nodes {
+        walk(n, &mut out);
+    }
+    out
+}
+
+/// True if the node's role makes it a clickable target for SoM overlays.
+pub fn is_interactive(n: &SnapshotNode) -> bool {
+    matches!(
+        n.role.as_str(),
+        "link" | "button" | "textbox" | "combobox" | "checkbox" | "radio" | "select" | "option"
+    )
 }
 
 #[cfg(test)]

--- a/crates/lightbrowse-core/src/vision.rs
+++ b/crates/lightbrowse-core/src/vision.rs
@@ -1,0 +1,128 @@
+//! Set-of-Mark (SoM) overlay — the "eyes" of human-like perception.
+//!
+//! Takes a screenshot + bounding boxes and draws numbered red frames over the
+//! interactive elements, so a vision LLM can say "click number 7" exactly like
+//! a human pointing at the screen. Numbers are rendered with a tiny embedded
+//! 5×7 bitmap font — no font file, no extra binary weight.
+
+use image::{Rgba, RgbaImage};
+
+use crate::error::Result;
+use crate::snapshot::{Bbox, SnapshotNode, SnapshotTree};
+
+/// A numbered mark drawn onto the screenshot.
+pub struct Mark {
+    pub label: usize,
+    pub bbox: Bbox,
+}
+
+const RED: Rgba<u8> = Rgba([220, 38, 38, 255]);
+const WHITE: Rgba<u8> = Rgba([255, 255, 255, 255]);
+
+/// Classic 5×7 bitmap font, digits 0-9 (bit 4 = leftmost column).
+const FONT: [[u8; 7]; 10] = [
+    [0b01110, 0b10001, 0b10011, 0b10101, 0b11001, 0b10001, 0b01110], // 0
+    [0b00100, 0b01100, 0b00100, 0b00100, 0b00100, 0b00100, 0b01110], // 1
+    [0b01110, 0b10001, 0b00001, 0b00010, 0b00100, 0b01000, 0b11111], // 2
+    [0b11111, 0b00010, 0b00100, 0b00010, 0b00001, 0b10001, 0b01110], // 3
+    [0b00010, 0b00110, 0b01010, 0b10010, 0b11111, 0b00010, 0b00010], // 4
+    [0b11111, 0b10000, 0b11110, 0b00001, 0b00001, 0b10001, 0b01110], // 5
+    [0b00110, 0b01000, 0b10000, 0b11110, 0b10001, 0b10001, 0b01110], // 6
+    [0b11111, 0b00001, 0b00010, 0b00100, 0b01000, 0b01000, 0b01000], // 7
+    [0b01110, 0b10001, 0b10001, 0b01110, 0b10001, 0b10001, 0b01110], // 8
+    [0b01110, 0b10001, 0b10001, 0b01111, 0b00001, 0b00010, 0b01100], // 9
+];
+
+#[inline]
+fn set(img: &mut RgbaImage, x: i64, y: i64, c: Rgba<u8>) {
+    if x >= 0 && y >= 0 && (x as u32) < img.width() && (y as u32) < img.height() {
+        img.put_pixel(x as u32, y as u32, c);
+    }
+}
+
+/// Draw the label digits on a white chip at the box's top-left corner.
+fn draw_label(img: &mut RgbaImage, x0: i64, y0: i64, label: usize) {
+    let digits: Vec<u8> = label.to_string().bytes().map(|b| b - b'0').collect();
+    let cw = 6i64; // digit width + spacing
+    let chip_w = digits.len() as i64 * cw + 2;
+    let chip_h = 9i64;
+    for py in y0..(y0 + chip_h) {
+        for px in x0..(x0 + chip_w) {
+            set(img, px, py, WHITE);
+        }
+    }
+    for (i, d) in digits.iter().enumerate() {
+        let ox = x0 + 1 + i as i64 * cw;
+        let oy = y0 + 1;
+        for (row, bits_row) in FONT[*d as usize].iter().enumerate() {
+            let bits = *bits_row;
+            for col in 0..5usize {
+                if bits & (1 << (4 - col as i32)) != 0 {
+                    set(img, ox + col as i64, oy + row as i64, RED);
+                }
+            }
+        }
+    }
+}
+
+/// Overlay numbered frames on a PNG screenshot. Marks fully outside the
+/// viewport or with zero area are skipped.
+pub fn overlay(png: &[u8], marks: &[Mark]) -> Result<Vec<u8>> {
+    let img = image::load_from_memory(png)
+        .map_err(|e| crate::error::Error::Parse(format!("overlay decode: {e}")))?;
+    let mut rgb = img.to_rgba8();
+    let (w, h) = (rgb.width() as i64, rgb.height() as i64);
+
+    for m in marks {
+        let x0 = m.bbox.x.max(0.0) as i64;
+        let y0 = m.bbox.y.max(0.0) as i64;
+        let x1 = ((m.bbox.x + m.bbox.w).min(w as f64)) as i64;
+        let y1 = ((m.bbox.y + m.bbox.h).min(h as f64)) as i64;
+        if x1 <= x0 || y1 <= y0 {
+            continue;
+        }
+        // 1px red frame.
+        for px in x0..x1 {
+            set(&mut rgb, px, y0, RED);
+            set(&mut rgb, px, y1.saturating_sub(1), RED);
+        }
+        for py in y0..y1 {
+            set(&mut rgb, x0, py, RED);
+            set(&mut rgb, x1.saturating_sub(1), py, RED);
+        }
+        // Label chip pinned inside the frame.
+        let (lx, ly) = (x0 + 2, y0 + 2);
+        if lx + 12 < x1 && ly + 9 < y1 {
+            draw_label(&mut rgb, lx, ly, m.label);
+        }
+    }
+
+    let mut out = std::io::Cursor::new(Vec::new());
+    image::DynamicImage::ImageRgba8(rgb)
+        .write_to(&mut out, image::ImageFormat::Png)
+        .map_err(|e| crate::error::Error::Parse(format!("overlay encode: {e}")))?;
+    Ok(out.into_inner())
+}
+
+/// Pick interactive nodes (with bboxes) from a snapshot tree and assign SoM
+/// labels in tree order. Returns (label, uid, text, bbox).
+pub fn select_marks(tree: &SnapshotTree, max: usize) -> Vec<(usize, u64, String, Bbox)> {
+    fn walk(n: &SnapshotNode, acc: &mut Vec<(u64, String, Bbox)>) {
+        if crate::snapshot::is_interactive(n) {
+            if let Some(b) = n.bbox {
+                if b.w >= 1.0 && b.h >= 1.0 {
+                    acc.push((n.uid, n.text.clone(), b));
+                }
+            }
+        }
+        for c in &n.children {
+            walk(c, acc);
+        }
+    }
+    let mut els = Vec::new();
+    for n in &tree.nodes {
+        walk(n, &mut els);
+    }
+    els.truncate(max);
+    els.into_iter().enumerate().map(|(i, (uid, text, b))| (i + 1, uid, text, b)).collect()
+}

--- a/crates/lightbrowse-http/Cargo.toml
+++ b/crates/lightbrowse-http/Cargo.toml
@@ -16,4 +16,5 @@ tokio = { workspace = true }
 axum = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+base64 = "0.22"
 tracing = { workspace = true }

--- a/crates/lightbrowse-http/src/lib.rs
+++ b/crates/lightbrowse-http/src/lib.rs
@@ -23,6 +23,7 @@ use lightbrowse_core::config::{Config, Engine};
 use lightbrowse_core::extract::{self, ExtractMode};
 use lightbrowse_core::session::Session;
 use lightbrowse_core::snapshot::{self, SnapshotOptions};
+use lightbrowse_core::vision;
 use lightbrowse_memory::{navigate_cached, MemoryStore};
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -57,6 +58,8 @@ pub fn router(state: AppState) -> Router {
         .route("/v1/runbook/get", get(runbook_get))
         .route("/v1/runbook/run", axum::routing::post(runbook_run))
         .route("/v1/click", get(click_action))
+        .route("/v1/click_at", get(click_at_action))
+        .route("/v1/visual_snapshot", get(visual_snapshot))
         .route("/v1/type", get(type_action))
         .route("/v1/submit", get(submit_action))
         .route("/v1/tabs", get(tabs_list))
@@ -688,6 +691,8 @@ fn openapi_spec() -> Value {
             "/v1/evaluate": { "get": { "summary": "Run JS on the active CDP tab", "parameters": [{"name": "expression", "in": "query", "required": true, "schema": {"type": "string"}}], "responses": { "200": {"description": "JS result"} } } },
             "/v1/screenshot": { "get": { "summary": "Screenshot the active CDP tab", "responses": { "200": {"description": "PNG"} } } },
             "/v1/click": { "get": { "summary": "Click a CSS selector on the active tab", "parameters": [{"name": "selector", "in": "query", "required": true, "schema": {"type": "string"}}], "responses": { "200": {"description": "click result"} } } },
+            "/v1/click_at": { "get": { "summary": "Click at viewport coordinates (CSS px) — the human-pointing action for SoM/vision", "parameters": [{"name": "x", "in": "query", "required": true, "schema": {"type": "number"}}, {"name": "y", "in": "query", "required": true, "schema": {"type": "number"}}], "responses": { "200": {"description": "click result"} } } },
+            "/v1/visual_snapshot": { "get": { "summary": "Vision-grounded look: screenshot + Set-of-Mark numbered overlay + uid map (base64 image)", "parameters": [{"name": "max_marks", "in": "query", "schema": {"type": "integer"}}, {"name": "max_nodes", "in": "query", "schema": {"type": "integer"}}], "responses": { "200": {"description": "JSON with image_base64 + map"} } } },
             "/v1/type": { "get": { "summary": "Type text into an input on the active tab", "parameters": [{"name": "selector", "in": "query", "required": true, "schema": {"type": "string"}}, {"name": "text", "in": "query", "required": true, "schema": {"type": "string"}}], "responses": { "200": {"description": "type result"} } } },
             "/v1/tabs": { "get": { "summary": "List open CDP tabs", "responses": { "200": {"description": "tabs"} } } },
             "/v1/tab/close": { "get": { "summary": "Close a CDP tab", "parameters": [{"name": "session", "in": "query", "schema": {"type": "string"}}], "responses": { "200": {"description": "ok"} } } },
@@ -842,6 +847,97 @@ async fn click_action(
         .await
         .map_err(ApiError::from)?;
     Ok(Json(json!({ "selector": q.selector, "result": res })).into_response())
+}
+
+#[derive(Deserialize)]
+struct CoordQuery {
+    x: f64,
+    y: f64,
+    /// Optional session id.
+    session: Option<String>,
+}
+
+async fn click_at_action(
+    State(state): State<AppState>,
+    Query(q): Query<CoordQuery>,
+) -> Result<Response, ApiError> {
+    let cdp_session = resolve_cdp_session(&state, q.session.as_deref())?;
+    let res = require_cdp(&state)?
+        .click_at(q.x, q.y, cdp_session.as_deref())
+        .await
+        .map_err(ApiError::from)?;
+    Ok(Json(json!({ "x": q.x, "y": q.y, "result": res })).into_response())
+}
+
+#[derive(Deserialize)]
+struct VisualQuery {
+    /// Optional session id.
+    session: Option<String>,
+    max_marks: Option<usize>,
+    max_nodes: Option<usize>,
+}
+
+/// Vision-grounded look: screenshot + SoM numbered overlay + uid map.
+async fn visual_snapshot(
+    State(state): State<AppState>,
+    Query(q): Query<VisualQuery>,
+) -> Result<Response, ApiError> {
+    let cdp_session = resolve_cdp_session(&state, q.session.as_deref())?;
+    let cdp = require_cdp(&state)?;
+    let max_nodes = q.max_nodes.unwrap_or(400).clamp(10, 2000);
+    let max_marks = q.max_marks.unwrap_or(40).clamp(1, 200);
+
+    let (html, title, url) = cdp
+        .current_dom(cdp_session.as_deref())
+        .await
+        .map_err(ApiError::from)?;
+    let opts = SnapshotOptions {
+        max_nodes,
+        max_depth: 12,
+        ..SnapshotOptions::default()
+    };
+    let mut tree = snapshot::snapshot(&html, &url, &opts);
+    let sels = snapshot::collect_selectors(&tree);
+    let rects = cdp
+        .element_rects(&sels, cdp_session.as_deref())
+        .await
+        .map_err(ApiError::from)?;
+    snapshot::attach_rects(&mut tree, &rects);
+
+    let shot = std::env::temp_dir().join(format!("lb-shot-{}.png", std::process::id()));
+    let shot_path = cdp
+        .screenshot(&shot, false, cdp_session.as_deref())
+        .await
+        .map_err(ApiError::from)?;
+    let png = std::fs::read(&shot_path)
+        .map_err(|e| ApiError::internal(format!("read screenshot: {e}")))?;
+    let marks = vision::select_marks(&tree, max_marks);
+    let som_marks: Vec<vision::Mark> = marks
+        .iter()
+        .map(|(label, _, _, b)| vision::Mark { label: *label, bbox: *b })
+        .collect();
+    let overlaid = vision::overlay(&png, &som_marks).map_err(ApiError::from)?;
+
+    let mut map = serde_json::Map::new();
+    for (label, uid, text, bbox) in &marks {
+        map.insert(
+            label.to_string(),
+            json!({
+                "uid": uid,
+                "text": text,
+                "bbox": [bbox.x, bbox.y, bbox.w, bbox.h]
+            }),
+        );
+    }
+    let b64 = base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &overlaid);
+    Ok(Json(json!({
+        "url": url,
+        "title": title,
+        "count": marks.len(),
+        "image_base64": b64,
+        "map": map
+    }))
+    .into_response())
 }
 
 async fn type_action(

--- a/crates/lightbrowse-mcp/Cargo.toml
+++ b/crates/lightbrowse-mcp/Cargo.toml
@@ -16,3 +16,4 @@ tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
+base64 = "0.22"

--- a/crates/lightbrowse-mcp/src/lib.rs
+++ b/crates/lightbrowse-mcp/src/lib.rs
@@ -13,6 +13,7 @@ use lightbrowse_core::config::Engine;
 use lightbrowse_core::extract::{self, ExtractMode};
 use lightbrowse_core::session::Session;
 use lightbrowse_core::snapshot::{self, SnapshotOptions};
+use lightbrowse_core::vision;
 use lightbrowse_memory::{navigate_cached, MemoryStore};
 use serde_json::{json, Map, Value};
 use tokio::io::{AsyncBufReadExt, BufReader};
@@ -146,7 +147,7 @@ impl McpServer {
                     "serverInfo": {
                         "name": "lightbrowse",
                         "version": env!("CARGO_PKG_VERSION"),
-                        "description": "Featherweight browser MCP. 31 tools in 7 groups: [Read] fetch/extract/snapshot/search/ask — [Act] click/type/submit/press/evaluate/screenshot/page/current on live CDP tabs — [Download] download/downloads — [Research] research/memory/search — [Runbook] trail/clear + runbook/* — [Session] tabs/list + tab/close — [Network] proxy/get + proxy/set + network/capture + cookies — [Vault] vault/set + vault/list + vault/get + vault/delete (encrypted credentials). engine=auto picks fetch first, falls back to headless Chromium; engine=cdp keeps a live tab for actions. Call the 'help' tool for the grouped catalog with use-cases."
+                        "description": "Featherweight browser MCP. 33 tools in 7 groups: [Read] fetch/extract/snapshot/search/ask — [Act] click/click_at/visual_snapshot/type/submit/press/evaluate/screenshot/page/current on live CDP tabs — [Download] download/downloads — [Research] research/memory/search — [Runbook] trail/clear + runbook/* — [Session] tabs/list + tab/close — [Network] proxy/get + proxy/set + network/capture + cookies — [Vault] vault/set + vault/list + vault/get + vault/delete (encrypted credentials). engine=auto picks fetch first, falls back to headless Chromium; engine=cdp keeps a live tab for actions. visual_snapshot = SoM numbered overlay for human-like vision agents; click_at = coordinate click. Call the 'help' tool for the grouped catalog with use-cases."
                     }
                 }
             })),
@@ -325,7 +326,7 @@ impl McpServer {
                 }
             }
             "help" => Ok(pretty(&json!({
-                "about": "lightbrowse — featherweight browser MCP. 31 tools in 7 groups.",
+                "about": "lightbrowse — featherweight browser MCP. 33 tools in 7 groups.",
                 "workflow": [
                     "1. navigate (engine=auto for plain pages, engine=cdp for JS/login-heavy apps)",
                     "2. snapshot / extract / ask to understand the page",
@@ -343,7 +344,7 @@ impl McpServer {
                     {
                         "tag": "[Act]",
                         "when": "operate on a live engine=cdp tab (login forms, buttons, JS state)",
-                        "tools": ["click", "type", "submit", "press", "evaluate", "screenshot", "page/current"]
+                        "tools": ["click", "click_at", "visual_snapshot", "type", "submit", "press", "evaluate", "screenshot", "page/current"]
                     },
                     {
                         "tag": "[Research]",
@@ -670,6 +671,100 @@ impl McpServer {
                     .await
                     .map_err(|e| e.to_string())?;
                 Ok(pretty(&json!({ "selector": selector, "result": res })))
+            }
+            "click_at" => {
+                let x = args
+                    .get("x")
+                    .and_then(|v| v.as_f64())
+                    .ok_or("click_at: x (number) required")?;
+                let y = args
+                    .get("y")
+                    .and_then(|v| v.as_f64())
+                    .ok_or("click_at: y (number) required")?;
+                let cdp = require_cdp(&s)?;
+                let session = opt_str(args, "session");
+                let res = cdp
+                    .click_at(x, y, session.as_deref())
+                    .await
+                    .map_err(|e| e.to_string())?;
+                Ok(pretty(&json!({ "x": x, "y": y, "result": res })))
+            }
+            "visual_snapshot" => {
+                let cdp = require_cdp(&s)?;
+                let session = opt_str(args, "session");
+                let max_nodes = args
+                    .get("max_nodes")
+                    .and_then(|n| n.as_u64())
+                    .map(|n| n as usize)
+                    .unwrap_or(400)
+                    .clamp(10, 2000);
+                let max_marks = args
+                    .get("max_marks")
+                    .and_then(|n| n.as_u64())
+                    .map(|n| n as usize)
+                    .unwrap_or(40)
+                    .clamp(1, 200);
+
+                // 1. Current rendered document (no re-navigate).
+                let (html, title, url) = cdp
+                    .current_dom(session.as_deref())
+                    .await
+                    .map_err(|e| e.to_string())?;
+
+                // 2. Snapshot tree + bboxes via one JS pass.
+                let opts = SnapshotOptions {
+                    max_nodes,
+                    max_depth: 12,
+                    ..SnapshotOptions::default()
+                };
+                let mut tree = snapshot::snapshot(&html, &url, &opts);
+                let sels = snapshot::collect_selectors(&tree);
+                let rects = cdp
+                    .element_rects(&sels, session.as_deref())
+                    .await
+                    .map_err(|e| e.to_string())?;
+                snapshot::attach_rects(&mut tree, &rects);
+
+                // 3. Screenshot → overlay numbered frames → map.
+                let shot = std::env::temp_dir().join(format!(
+                    "lb-shot-{}.png",
+                    std::process::id()
+                ));
+                let shot_path = cdp
+                    .screenshot(&shot, false, session.as_deref())
+                    .await
+                    .map_err(|e| e.to_string())?;
+                let png = std::fs::read(&shot_path).map_err(|e| e.to_string())?;
+                let marks = vision::select_marks(&tree, max_marks);
+                let som_marks: Vec<vision::Mark> = marks
+                    .iter()
+                    .map(|(label, _, _, b)| vision::Mark { label: *label, bbox: *b })
+                    .collect();
+                let overlaid = vision::overlay(&png, &som_marks).map_err(|e| e.to_string())?;
+
+                let mut map = serde_json::Map::new();
+                for (label, uid, text, bbox) in &marks {
+                    map.insert(
+                        label.to_string(),
+                        json!({
+                            "uid": uid,
+                            "text": text,
+                            "bbox": [bbox.x, bbox.y, bbox.w, bbox.h]
+                        }),
+                    );
+                }
+                let b64 = base64::Engine::encode(
+                    &base64::engine::general_purpose::STANDARD,
+                    &overlaid,
+                );
+                Ok(pretty(&json!({
+                    "url": url,
+                    "title": title,
+                    "count": marks.len(),
+                    "image_base64": b64,
+                    "map": map,
+                    "note": "The image has numbered red frames. Reply with the number(s) that match your goal, e.g. 'click 7' or '7 = login'."
+                })))
             }
             "type" => {
                 let selector = req_str(args, "selector")?;
@@ -1123,6 +1218,32 @@ fn tools_schema() -> Vec<Value> {
             }
         }),
         json!({
+            "name": "click_at",
+            "description": "Click at raw viewport coordinates (CSS px, top-left origin) — the human-pointing action for SoM/vision workflows. Pair with visual_snapshot: pick a number, click its bbox center.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "x": { "type": "number", "description": "viewport x (CSS px)" },
+                    "y": { "type": "number", "description": "viewport y (CSS px)" },
+                    "session": { "type": "string", "description": "optional session id" }
+                },
+                "required": ["x", "y"]
+            }
+        }),
+        json!({
+            "name": "visual_snapshot",
+            "description": "Vision-grounded look at the ACTIVE tab: screenshot with numbered red frames (Set-of-Mark) over interactive elements + a JSON map (number -> uid/text/bbox). The host LLM sees the image and answers with numbers, like a human pointing. Works with non-vision hosts too via the map. Click the center of a bbox with click_at.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "max_marks": { "type": "integer", "minimum": 1, "maximum": 200, "default": 40, "description": "max numbered elements to draw" },
+                    "max_nodes": { "type": "integer", "minimum": 10, "maximum": 2000, "default": 400 },
+                    "session": { "type": "string", "description": "optional session id" }
+                },
+                "required": []
+            }
+        }),
+        json!({
             "name": "type",
             "description": "Type text into an input/textarea on the ACTIVE CDP tab (React-compatible events).",
             "inputSchema": {
@@ -1271,6 +1392,8 @@ fn tools_schema() -> Vec<Value> {
         ("ask", "[Read]"),
         // [Act] — operate on a live engine=cdp tab.
         ("click", "[Act]"),
+        ("click_at", "[Act]"),
+        ("visual_snapshot", "[Act]"),
         ("type", "[Act]"),
         ("submit", "[Act]"),
         ("press", "[Act]"),

--- a/tools/gemini-vision.py
+++ b/tools/gemini-vision.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""
+gemini-vision.py — free vision for lightbrowse (no API key).
+
+Sends a screenshot (or any image) to Gemini via the reverse-engineered web API
+and returns a text answer. This is the "eyes" of the VisionProvider design
+(issue #36 Option A): lightbrowse provides screenshot + bbox map, Gemini
+answers "which number is the login button?" → number → click_at.
+
+Cookie is auto-detected from a running Chrome via CDP (port 9222) — zero setup
+if Chrome is logged into gemini.google.com. Falls back to config file.
+
+Usage:
+  python3 tools/gemini-vision.py --image shot.png --prompt "Which number is the login button? Reply with just the number."
+  python3 tools/gemini-vision.py --image shot.png --prompt "Where is the news section?" --json
+  python3 tools/gemini-vision.py --image shot.png --prompt "Describe this page layout briefly."
+
+Deps: pip install gemini-webapi
+"""
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import urllib.request
+from pathlib import Path
+
+try:
+    from gemini_webapi import GeminiClient
+except ImportError:
+    print(
+        "❌ gemini-webapi missing. Install: pip3 install gemini-webapi --break-system-packages",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+CONFIG_FILE = Path(__file__).resolve().parent.parent / ".gemini-vision.json"
+MODEL_DEFAULT = "gemini-3-flash"
+
+
+def _cdp_get_cookies():
+    """Auto-extract __Secure-1PSID(+TS) from running Chrome via CDP."""
+    try:
+        with urllib.request.urlopen("http://127.0.0.1:9222/json", timeout=3) as r:
+            targets = json.loads(r.read())
+        ws_url = next(
+            (t.get("webSocketDebuggerUrl") for t in targets if t.get("webSocketDebuggerUrl")),
+            None,
+        )
+        if not ws_url:
+            return None, None
+        import websockets
+
+        async def _fetch():
+            async with websockets.connect(
+                ws_url, max_size=5 * 1024 * 1024, open_timeout=5
+            ) as ws:
+                await ws.send(json.dumps({"id": 1, "method": "Network.enable"}))
+                await asyncio.wait_for(ws.recv(), timeout=5)
+                await ws.send(json.dumps({"id": 2, "method": "Network.getCookies"}))
+                resp = json.loads(await asyncio.wait_for(ws.recv(), timeout=5))
+                cookies = resp.get("result", {}).get("cookies", [])
+                spsid = next(
+                    (c["value"] for c in cookies if c.get("name") == "__Secure-1PSID"), None
+                )
+                spsidts = next(
+                    (c["value"] for c in cookies if c.get("name") == "__Secure-1PSIDTS"), None
+                )
+                return spsid, spsidts
+
+        return asyncio.run(_fetch())
+    except Exception:
+        return None, None
+
+
+def ensure_cookie() -> tuple[str, str | None]:
+    """Cookie from config file or live CDP detection."""
+    if CONFIG_FILE.exists():
+        try:
+            cfg = json.loads(CONFIG_FILE.read_text())
+            if cfg.get("secure_1psid"):
+                return cfg["secure_1psid"], cfg.get("secure_1psidts")
+        except (json.JSONDecodeError, OSError):
+            pass
+    print("🔍 Auto-detecting cookie from Chrome...", file=sys.stderr)
+    spsid, spsidts = _cdp_get_cookies()
+    if spsid:
+        try:
+            CONFIG_FILE.parent.mkdir(exist_ok=True)
+            CONFIG_FILE.write_text(
+                json.dumps({"secure_1psid": spsid, "secure_1psidts": spsidts})
+            )
+        except OSError:
+            pass
+        print("✅ Auto-detected!", file=sys.stderr)
+        return spsid, spsidts
+    print(
+        "❌ No cookie found. Open Chrome (port 9222) logged into gemini.google.com, "
+        "or write .gemini-vision.json with {\"secure_1psid\": \"...\"}.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+async def run(image: str, prompt: str, model: str, json_out: bool) -> None:
+    if not os.path.exists(image):
+        print(f"❌ Image not found: {image}", file=sys.stderr)
+        sys.exit(1)
+    spsid, spsidts = ensure_cookie()
+    try:
+        client = GeminiClient(spsid, spsidts or None)
+        await client.init(timeout=120, auto_refresh=False, verbose=False)
+        print(f"📷 {image} → {model}", file=sys.stderr)
+        # Chat flow (start_chat + send_message) — more robust than the raw
+        # generate_content path against the reverse-engineered web API.
+        chat = client.start_chat(model=model)
+        resp = await chat.send_message(prompt, files=[image], temporary=True)
+        text = resp.text or ""
+    except Exception as e:
+        print(f"❌ Gemini error: {e}", file=sys.stderr)
+        sys.exit(1)
+    finally:
+        try:
+            await client.close()
+        except Exception:
+            pass
+
+    if json_out:
+        print(json.dumps({"text": text}, ensure_ascii=False))
+    else:
+        print(text)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Free Gemini vision for lightbrowse")
+    ap.add_argument("--image", required=True, help="path to screenshot/image")
+    ap.add_argument("--prompt", required=True, help="question about the image")
+    ap.add_argument("--model", default=MODEL_DEFAULT, help=f"gemini model (default {MODEL_DEFAULT})")
+    ap.add_argument("--json", action="store_true", help="emit JSON output")
+    args = ap.parse_args()
+    asyncio.run(run(args.image, args.prompt, args.model, args.json))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Human-like perception for lightbrowse — the agent now **looks at the screen** (Set-of-Mark overlay) and **points** (coordinate click) instead of only poking the DOM.

1. **bbox per snapshot node** (#33) — `x/y/w/h` viewport rects via one `getBoundingClientRect` JS pass (CDP engine; fetch omits). Purely additive; also gives text-only LLMs spatial reasoning.
2. **`visual_snapshot` tool** (#34) — screenshot + numbered red frames (SoM) over interactive elements + `number→{uid,text,bbox}` map. Exposed MCP / HTTP (`/v1/visual_snapshot`) / CLI (`visual-snapshot`). max_depth 12 for dense pages; `--settle-ms` waits out bot challenges.
3. **`click_at(x,y)`** (#35) — coordinate click via `Input.dispatchMouseEvent`; MCP / HTTP (`/v1/click_at`) / CLI (`click-at`).
4. **`tools/gemini-vision.py`** — FREE Gemini Web vision sidecar (reverse-engineered web API, no API key, CDP cookie auto-detect): sends screenshot+prompt, returns "number 7". Lets non-vision host LLMs reason visually — vision becomes a lightbrowse feature, not a host feature (#36 Option A).

SoM numbers drawn with an embedded 5×7 bitmap font — no font files, no binary weight.

## Live verification (voz.vn)

- Homepage → 40 numbered marks with pixel-correct bboxes (Log in @1103,57 · Register @1170,57 · Đại sảnh @21,406 …)
- Gemini (gemini-3-flash, free) read the overlay and correctly identified elements + recommended threads (Bóng Đá VN mùa giải 25/26, Anh em ở Nhật 3.0, Senior Member guide)
- `click_at(63,418)` on Đại sảnh navigated to `voz.vn/#dai-sanh.1` ✓

clippy clean, workspace tests pass.

Closes #33, #34, #35 (sidecar part of #36 tracked separately).