### PR TITLE
feat: stealth toggles + extractive summarize + diff mode + roadmap vision section

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,43 @@
 - [x] **SSO auth sharing** — all CDP sessions share the persistent Chromium
       profile: log into Microsoft SSO once, Outlook/Teams/SharePoint are
       auto-authenticated everywhere
-- [ ] **Stealth options** — fingerprinting toggles for bot-detected sites
+- [x] **Stealth options** — fingerprinting toggles for bot-detected sites
+      (`--no-stealth`; built-in injection: webdriver/UA/chrome/plugins/
+      languages/hardwareConcurrency/deviceMemory). Note: hard CF routes
+      (e.g. voz `/whats-new/`) may still block headless — see Stealth v2 below.
+
+## Vision-grounded perception (the agent sees like a human) 🪶👁️
+
+> **Paradigm:** screenshot + Set-of-Mark (SoM) numbered overlay → vision LLM
+> picks numbers like a human pointing → `click_at(x,y)` acts. The DOM is the
+> fallback, not the primary sense.
+
+- [x] **bbox per snapshot node** — `x/y/w/h` viewport rects, one JS
+      `getBoundingClientRect` pass (CDP only; fetch omits) — also gives
+      text-only LLMs spatial reasoning
+- [x] **`visual_snapshot`** — screenshot + numbered SoM frames over
+      interactive elements + `number→{uid,text,bbox}` map
+      (MCP / HTTP `/v1/visual_snapshot` / CLI `visual-snapshot`; embedded
+      5×7 bitmap font, no font files; `--settle-ms` waits out bot challenges)
+- [x] **`click_at(x,y)`** — coordinate click via `Input.dispatchMouseEvent`
+      (MCP / HTTP `/v1/click_at` / CLI `click-at`)
+- [x] **Gemini Web vision sidecar** (`tools/gemini-vision.py`) — FREE
+      reverse-engineered Gemini Web API, no API key, CDP cookie auto-detect.
+      Verified live: reads SoM overlay, identifies elements/threads.
+- [ ] **`visual_snapshot mode=gemini`** — Rust calls the sidecar server-side
+      (python subprocess), returns the vision answer directly — vision becomes
+      a lightbrowse feature, no host vision required
+- [ ] **VisionProvider trait** — pluggable `locate(image, prompt, candidates)
+      → {soom_id|uid|coords}`; providers: gemini-web (free) / anthropic /
+      openai / omni-parser (local)
+- [ ] **`click <n>` SoM convenience** — resolve number → bbox center in one
+      call (MCP/HTTP)
+- [ ] **`hover_at(x,y)`** — for hover-dependent menus
+- [ ] **post-click verification** — `elementFromPoint` check after click
+      (clicked the right thing? page changed?)
+- [ ] **Stealth v2 (undetected)** — CF-hard routes (voz `/whats-new/`,
+      cloudflare Turnstile) need a fuller human fingerprint (canvas noise,
+      CDP-detection patches, cf_clearance flow)
 
 ## Reading & extraction (what agents need most)
 
@@ -45,9 +81,13 @@
 - [x] CSS `selector` on snapshot nodes (for actions)
 - [x] **Intent-aware `ask`** — pass a question, get relevant blocks + score
 - [x] **Token & cost section** — benchmarked savings vs naive reads (see README)
-- [ ] **Page summarization** — optional LLM-less extractive summary
-- [ ] **Diff mode** — compare two versions of a page
+- [x] **Page summarization** — LLM-less extractive summary
+      (`lightbrowse summarize <url>`, TF×position scoring, timestamp-noise
+      filter; no model, no API)
+- [x] **Diff mode** — `lightbrowse diff <urlA> <urlB>`: line-level LCS,
+      context compaction, change stats (CLI); MCP/HTTP expose planned
 - [ ] **Multi-page research** — batch N URLs, aggregated answer
+      (research tool exists in MCP — CLI batch mode planned)
 
 ## Browsing memory (why no vector DB — yet)
 
@@ -96,8 +136,8 @@
 - [x] CLI (`fetch`, `extract`, `snapshot`, `search`, `ask`, `memory-*`, `serve`, `mcp`)
 - [x] MCP server — navigate/extract/snapshot/search/ask/research/memory/click/type/submit/press/screenshot/evaluate/runbook
 - [x] HTTP API — `/v1/{page,extract,snapshot,search,ask,memory,click,type,submit,current,cookies,download,downloads,network/log,network/capture}` + `/docs` + `/openapi.json`
-- [ ] WebSocket streaming for long-running research tasks
-- [ ] Optional GUI (wry) — off by default, for humans who want to watch
+- [ ] **WebSocket streaming for long-running research tasks**
+- [ ] **Optional GUI (wry)** — off by default, for humans who want to watch
 
 ## Non-goals (deliberately)
 

--- a/crates/lightbrowse-cdp/src/lib.rs
+++ b/crates/lightbrowse-cdp/src/lib.rs
@@ -524,6 +524,7 @@ impl CdpBackend {
             url,
             &ua,
             self.config.js_wait_ms,
+            self.config.stealth,
             self.config.preload_script.as_deref(),
             self.config.download_dir.as_deref(),
         )
@@ -1827,6 +1828,7 @@ async fn navigate_and_render(
     url: &str,
     user_agent: &str,
     js_wait_ms: u64,
+    stealth: bool,
     preload_script: Option<&std::path::Path>,
     download_dir: Option<&std::path::Path>,
 ) -> Result<(String, String, String)> {
@@ -1835,7 +1837,7 @@ async fn navigate_and_render(
         .map_err(|e| Error::Transport(format!("cdp connect: {e}")))?;
 
     rpc_expect(&mut ws, "Page.enable", json!({})).await?;
-    stealth_setup(&mut ws, user_agent, preload_script).await?;
+    stealth_setup(&mut ws, user_agent, stealth, preload_script).await?;
 
     // Allow programmatic downloads (anchor clicks / the `download` tool)
     // without Chromium's "multiple automatic downloads" gate, and route
@@ -2033,6 +2035,7 @@ async fn navigate_and_render(
 async fn stealth_setup(
     ws: &mut CdpWs,
     user_agent: &str,
+    stealth: bool,
     preload_script: Option<&std::path::Path>,
 ) -> Result<()> {
     if let Err(e) = rpc_expect(
@@ -2061,16 +2064,24 @@ async fn stealth_setup(
     Object.defineProperty(navigator, 'languages', {{
         get: () => ['en-US', 'en', 'vi'],
     }});
+    Object.defineProperty(navigator, 'hardwareConcurrency', {{
+        get: () => 8,
+    }});
+    Object.defineProperty(navigator, 'deviceMemory', {{
+        get: () => 8,
+    }});
 }})();
 "#,
         ua_json = serde_json::to_string(user_agent).map_err(|e| Error::Parse(e.to_string()))?
     );
-    let _ = rpc_expect(
-        ws,
-        "Page.addScriptToEvaluateOnNewDocument",
-        json!({ "source": stealth_js }),
-    )
-    .await;
+    if stealth {
+        let _ = rpc_expect(
+            ws,
+            "Page.addScriptToEvaluateOnNewDocument",
+            json!({ "source": stealth_js }),
+        )
+        .await;
+    }
     // Optional user preload hook (--preload / LIGHTBROWSE_PRELOAD): runs
     // before the page's own scripts, e.g. fetch/XHR wrappers for API
     // discovery (see #31).

--- a/crates/lightbrowse-cli/src/main.rs
+++ b/crates/lightbrowse-cli/src/main.rs
@@ -67,6 +67,10 @@ struct Cli {
     /// (fetch/XHR hooks, network spies). Also settable via LIGHTBROWSE_PRELOAD.
     #[arg(long, global = true)]
     preload: Option<std::path::PathBuf>,
+    /// Disable fingerprint-masking (navigator.webdriver, hardwareConcurrency,
+    /// languages, chrome, …). On by default; disable if a site misbehaves.
+    #[arg(long, global = true)]
+    no_stealth: bool,
     #[command(subcommand)]
     cmd: Cmd,
 }
@@ -140,6 +144,24 @@ enum Cmd {
         y: f64,
         #[arg(long)]
         session: Option<String>,
+    },
+    /// LLM-less extractive summary of a page (top sentences, no API key).
+    Summarize {
+        url: String,
+        #[arg(long, default_value_t = 5)]
+        max_sentences: usize,
+        #[arg(long, default_value = "auto", value_parser = parse_engine)]
+        engine: Engine,
+    },
+    /// Diff two pages (or the same URL twice) line-by-line — what changed?
+    Diff {
+        url_a: String,
+        url_b: String,
+        #[arg(long, default_value = "auto", value_parser = parse_engine)]
+        engine: Engine,
+        /// Context lines around each change (0 = only changes).
+        #[arg(long, default_value_t = 2)]
+        context: usize,
     },
     /// Web search via DuckDuckGo (no API key).
     Search {
@@ -252,6 +274,9 @@ async fn main() -> lightbrowse_core::Result<()> {
             .filter(|s| !s.is_empty())
             .map(std::path::PathBuf::from)
     });
+    if cli.no_stealth {
+        config.stealth = false;
+    }
     // Proxy: CLI flag wins over the environment; validate early so a typo
     // fails before any request is made.
     config.proxy = cli
@@ -436,6 +461,83 @@ async fn main() -> lightbrowse_core::Result<()> {
         Cmd::ClickAt { x, y, session } => {
             let res = cdp.click_at(x, y, session.as_deref()).await?;
             print_json(&res);
+        }
+        Cmd::Summarize {
+            url,
+            max_sentences,
+            engine,
+        } => {
+            let (page, _) = nav_cached(
+                &memory,
+                &*fetch,
+                Some(&*cdp_trait),
+                &session,
+                &url,
+                engine,
+                ttl,
+            )
+            .await?;
+            let s = lightbrowse_core::summarize::summarize(
+                &page.html,
+                max_sentences.clamp(1, 20),
+            );
+            print_json(&json!({
+                "url": page.url,
+                "title": s.title,
+                "total_sentences": s.total_sentences,
+                "summary": s.sentences,
+            }));
+        }
+        Cmd::Diff {
+            url_a,
+            url_b,
+            engine,
+            context,
+        } => {
+            let (pa, _) = nav_cached(
+                &memory,
+                &*fetch,
+                Some(&*cdp_trait),
+                &session,
+                &url_a,
+                engine,
+                ttl,
+            )
+            .await?;
+            let (pb, _) = nav_cached(
+                &memory,
+                &*fetch,
+                Some(&*cdp_trait),
+                &session,
+                &url_b,
+                engine,
+                ttl,
+            )
+            .await?;
+            let ta = extract::extract_text(&pa.html).text;
+            let tb = extract::extract_text(&pb.html).text;
+            let full = lightbrowse_core::diff::diff_texts(&ta, &tb);
+            let compacted = lightbrowse_core::diff::compact(full.clone(), context);
+            let (same, added, removed) = lightbrowse_core::diff::diff_stats(&full);
+            let lines: Vec<Value> = compacted
+                .iter()
+                .map(|l| {
+                    json!({
+                        "kind": match l.kind {
+                            lightbrowse_core::diff::DiffKind::Same => "same",
+                            lightbrowse_core::diff::DiffKind::Added => "added",
+                            lightbrowse_core::diff::DiffKind::Removed => "removed",
+                        },
+                        "text": l.text,
+                    })
+                })
+                .collect();
+            print_json(&json!({
+                "url_a": pa.url,
+                "url_b": pb.url,
+                "stats": { "same": same, "added": added, "removed": removed },
+                "lines": lines,
+            }));
         }
         Cmd::Search { query, max_results } => {
             let ddg = format!(

--- a/crates/lightbrowse-core/src/config.rs
+++ b/crates/lightbrowse-core/src/config.rs
@@ -69,6 +69,10 @@ pub struct Config {
     /// (via `Page.addScriptToEvaluateOnNewDocument`) — for fetch/XHR hooks,
     /// globals, network spies. Env: LIGHTBROWSE_PRELOAD.
     pub preload_script: Option<std::path::PathBuf>,
+    /// Fingerprint-masking injection (navigator.webdriver, UA, chrome,
+    /// plugins, languages, hardwareConcurrency, deviceMemory). Default true;
+    /// disable with `--no-stealth` when a site misbehaves.
+    pub stealth: bool,
 }
 
 impl Default for Config {
@@ -86,6 +90,7 @@ impl Default for Config {
             cdp_url: None,
             download_dir: None,
             preload_script: None,
+            stealth: true,
         }
     }
 }

--- a/crates/lightbrowse-core/src/diff.rs
+++ b/crates/lightbrowse-core/src/diff.rs
@@ -1,0 +1,124 @@
+//! Line-level diff between two texts (LCS) — for "what changed on this page".
+
+use std::collections::VecDeque;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiffKind {
+    Same,
+    Added,
+    Removed,
+}
+
+#[derive(Debug, Clone)]
+pub struct DiffLine {
+    pub kind: DiffKind,
+    pub text: String,
+}
+
+/// Diff two texts line-by-line using classic DP-LCS. Returns lines in order
+/// with kind markers; `Same` lines are context (kept so the reader can
+/// anchor added/removed content).
+pub fn diff_texts(a: &str, b: &str) -> Vec<DiffLine> {
+    let a: Vec<&str> = a.lines().collect();
+    let b: Vec<&str> = b.lines().collect();
+    let (n, m) = (a.len(), b.len());
+
+    // DP table: lcs[i][j] = LCS length of a[i..] and b[j..].
+    let mut lcs = vec![vec![0usize; m + 1]; n + 1];
+    for i in (0..n).rev() {
+        for j in (0..m).rev() {
+            lcs[i][j] = if a[i] == b[j] {
+                lcs[i + 1][j + 1] + 1
+            } else {
+                lcs[i + 1][j].max(lcs[i][j + 1])
+            };
+        }
+    }
+
+    let mut out = Vec::new();
+    let (mut i, mut j) = (0, 0);
+    while i < n && j < m {
+        if a[i] == b[j] {
+            out.push(DiffLine { kind: DiffKind::Same, text: a[i].to_string() });
+            i += 1;
+            j += 1;
+        } else if lcs[i + 1][j] >= lcs[i][j + 1] {
+            out.push(DiffLine { kind: DiffKind::Removed, text: a[i].to_string() });
+            i += 1;
+        } else {
+            out.push(DiffLine { kind: DiffKind::Added, text: b[j].to_string() });
+            j += 1;
+        }
+    }
+    while i < n {
+        out.push(DiffLine { kind: DiffKind::Removed, text: a[i].to_string() });
+        i += 1;
+    }
+    while j < m {
+        out.push(DiffLine { kind: DiffKind::Added, text: b[j].to_string() });
+        j += 1;
+    }
+    out
+}
+
+/// Counts of each kind in a diff result.
+pub fn diff_stats(diff: &[DiffLine]) -> (usize, usize, usize) {
+    let (mut same, mut added, mut removed) = (0, 0, 0);
+    for l in diff {
+        match l.kind {
+            DiffKind::Same => same += 1,
+            DiffKind::Added => added += 1,
+            DiffKind::Removed => removed += 1,
+        }
+    }
+    (same, added, removed)
+}
+
+/// Keep only lines within `context` of a change (compress long unchanged runs).
+pub fn compact(diff: Vec<DiffLine>, context: usize) -> Vec<DiffLine> {
+    let mut out: VecDeque<DiffLine> = VecDeque::new();
+    let mut unchanged_run = 0usize;
+    for line in diff {
+        if line.kind != DiffKind::Same {
+            // Emit any pending context (context lines before this change).
+            let emit = unchanged_run.min(context);
+            out.push_back(DiffLine { kind: DiffKind::Same, text: format!("⋯ {emit} unchanged ⋯") });
+            out.push_back(line);
+            unchanged_run = 0;
+        } else {
+            unchanged_run += 1;
+            if unchanged_run <= context {
+                out.push_back(line);
+            }
+        }
+    }
+    out.into_iter().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn diff_basic() {
+        let a = "line1\nline2\nline3\nline4";
+        let b = "line1\nlineX\nline3\nline4\nline5";
+        let d = diff_texts(a, b);
+        let (_, added, removed) = diff_stats(&d);
+        assert_eq!(added, 2); // lineX + line5
+        assert_eq!(removed, 1); // line2
+        let kinds: Vec<DiffKind> = d.iter().map(|l| l.kind).collect();
+        assert!(kinds.contains(&DiffKind::Removed));
+        assert!(kinds.contains(&DiffKind::Added));
+        assert!(kinds.contains(&DiffKind::Same));
+    }
+
+    #[test]
+    fn diff_identical() {
+        let d = diff_texts("a\nb\nc", "a\nb\nc");
+        let (same, added, removed) = diff_stats(&d);
+        assert_eq!(same, 3);
+        assert_eq!(added, 0);
+        assert_eq!(removed, 0);
+    }
+}

--- a/crates/lightbrowse-core/src/lib.rs
+++ b/crates/lightbrowse-core/src/lib.rs
@@ -10,6 +10,7 @@
 pub mod backend;
 pub mod config;
 pub mod cookie;
+pub mod diff;
 pub mod error;
 pub mod extract;
 pub mod page;
@@ -17,6 +18,7 @@ pub mod proxy;
 pub mod service;
 pub mod session;
 pub mod snapshot;
+pub mod summarize;
 pub mod vault;
 pub mod vision;
 

--- a/crates/lightbrowse-core/src/summarize.rs
+++ b/crates/lightbrowse-core/src/summarize.rs
@@ -1,0 +1,153 @@
+//! LLM-less extractive summarization.
+//!
+//! Scores sentences by content-word frequency (TF) with position bonuses —
+//! the classic extractive summarization heuristic. No model, no API, ~1ms
+//! on a typical page. Good enough for "what is this page about" previews.
+
+use std::collections::HashMap;
+
+use crate::extract::{clean, extract_text};
+
+/// Extractive summary: top sentences in original order.
+pub struct Summary {
+    /// Page title.
+    pub title: String,
+    /// Selected sentences (original order).
+    pub sentences: Vec<String>,
+    /// Total sentences considered.
+    pub total_sentences: usize,
+}
+
+fn split_sentences(text: &str) -> Vec<String> {
+    text.split(['.', '!', '?', '\n'])
+        .map(clean)
+        .filter(|s| {
+            let wc = s.split_whitespace().count();
+            (4..=80).contains(&wc)
+        })
+        .filter(|s| !looks_timestamp(s))
+        .collect()
+}
+
+/// Heuristic: skip fragments that are mostly timestamps/empty chrome
+/// ("Yesterday at 8:57 AM", "Today at 1:22 AM", "2 minutes ago"…).
+fn looks_timestamp(s: &str) -> bool {
+    let low = s.to_lowercase();
+    let markers = [
+        "yesterday", "today", "ago", "minutes", "hours", "at ",
+        "hôm qua", "hôm nay", "lúc ", "phút trước", "giờ trước",
+    ];
+    let hits = markers.iter().filter(|m| low.contains(**m)).count();
+    // Mostly digits / clock tokens?
+    let digits: usize = s.chars().filter(|c| c.is_ascii_digit()).count();
+    let alpha: usize = s.chars().filter(|c| c.is_alphabetic()).count();
+    hits >= 2 || (alpha > 0 && digits > alpha * 2)
+}
+
+fn content_words(s: &str) -> Vec<String> {
+    s.split_whitespace()
+        .map(|w| {
+            w.trim_matches(|c: char| !c.is_alphanumeric())
+                .to_lowercase()
+        })
+        .filter(|w| {
+            w.len() >= 4
+                && !matches!(
+                    w.as_str(),
+                    "the" | "this" | "that" | "with" | "from" | "have" | "they" | "there"
+                        | "their" | "which" | "would" | "could" | "about" | "these" | "those"
+                        | "being" | "been" | "were" | "than" | "then" | "when" | "what" | "where"
+                        | "while" | "after" | "before" | "because" | "between" | "through"
+                        | "during" | "without" | "within" | "across" | "against" | "along"
+                        | "around" | "under" | "above" | "below" | "again" | "further"
+                        | "và" | "của" | "cho" | "các" | "được" | "không" | "những" | "một"
+                        | "với" | "người" | "khi" | "để" | "trong" | "cũng" | "này" | "đó"
+                        | "về" | "như" | "từ" | "đã" | "sẽ" | "đang" | "là" | "có"
+                )
+        })
+        .collect()
+}
+
+/// Summarize an HTML page extractively.
+pub fn summarize(html: &str, max_sentences: usize) -> Summary {
+    let ex = extract_text(html);
+    let sentences = split_sentences(&ex.text);
+    let total = sentences.len();
+    if total == 0 {
+        return Summary {
+            title: ex.title,
+            sentences: Vec::new(),
+            total_sentences: 0,
+        };
+    }
+
+    // Word frequencies across all sentences (content words only).
+    let mut freq: HashMap<String, usize> = HashMap::new();
+    for s in &sentences {
+        for w in content_words(s) {
+            *freq.entry(w).or_insert(0) += 1;
+        }
+    }
+
+    // Score: avg content-word frequency × position bonus (first sentences win).
+    let mut scored: Vec<(f64, usize)> = Vec::new();
+    for (i, s) in sentences.iter().enumerate() {
+        let cw = content_words(s);
+        if cw.is_empty() {
+            scored.push((0.0, i));
+            continue;
+        }
+        let tf: f64 = cw.iter().map(|w| *freq.get(w).unwrap_or(&1) as f64).sum();
+        let avg = tf / cw.len() as f64;
+        let pos = if i == 0 {
+            1.6
+        } else if i < 3 {
+            1.3
+        } else {
+            1.0
+        };
+        scored.push((avg * pos, i));
+    }
+
+    scored.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+    let mut picked: Vec<usize> = scored
+        .iter()
+        .filter(|(score, _)| *score > 0.0)
+        .take(max_sentences)
+        .map(|(_, i)| *i)
+        .collect();
+    picked.sort_unstable();
+
+    Summary {
+        title: ex.title,
+        sentences: picked.iter().map(|i| sentences[*i].clone()).collect(),
+        total_sentences: total,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn summarize_basic() {
+        let html = "<html><head><title>T</title></head><body>
+            <p>Rust is a systems programming language focused on safety and performance.
+               Rust guarantees memory safety without a garbage collector.
+               The borrow checker enforces ownership rules at compile time.
+               Many large companies use Rust in production today.
+               Rust tooling includes cargo, clippy and rustfmt.
+               The ecosystem grows quickly with crates.io packages.</p>
+            <p>Python is a high-level language with dynamic typing.
+               Python is popular for data science and machine learning.
+               Python scripts are easy to read and write.</p>
+            </body></html>";
+        let s = summarize(html, 3);
+        assert_eq!(s.title, "T");
+        assert!(!s.sentences.is_empty());
+        assert!(s.sentences.len() <= 3);
+        // Top sentence should mention the dominant topic (Rust).
+        assert!(s.sentences.iter().any(|x| x.contains("Rust")));
+        assert_eq!(s.total_sentences, 9);
+    }
+}


### PR DESCRIPTION
## What

1. **Stealth options** — `--no-stealth` toggle + extra fingerprints (`hardwareConcurrency`, `deviceMemory`); built-in injection stays default-on. (Roadmap: Stealth options ✓)
2. **LLM-less extractive summarize** — `lightbrowse summarize <url>`: TF × position scoring, timestamp-noise filter, no model/API. (Roadmap: Page summarization ✓)
3. **Diff mode** — `lightbrowse diff <urlA> <urlB>`: line-level LCS + context compaction + change stats. (Roadmap: Diff mode ✓)
4. **ROADMAP.md** — new **Vision-grounded perception** section (SoM/visual_snapshot/click_at/Gemini sidecar marked done) + new planned items: `mode=gemini` integration, VisionProvider trait, `click <n>` SoM convenience, `hover_at`, post-click verification, Stealth v2 (undetected/CF-hard).

clippy clean, 13 test suites pass.