### PR TITLE
feat: one-call login — auto-detect username+password fields, fill both, submit

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -107,6 +107,11 @@
 ## Actions (make the browser *do* things)
 
 - [x] **click(selector)** via CDP — real mouse events at element coordinates
+- [x] **click_at(x,y)** — coordinate click (SoM/vision “human pointing”)
+- [x] **login(username, password)** — ONE-CALL login: direct JS detection of
+      username+password fields (depth-independent), fill both, Enter to submit
+      (MCP `login` / HTTP `/v1/login` / CLI `login <url> <user> <pass>`;
+      secrets can reference the vault as `vault:<name>.field`)
 - [x] **type(selector, text)** — CDP `Input.insertText` (real keyboard events)
 - [x] **press(key)** — `Input.dispatchKeyEvent` (Enter/Tab/Backspace/...)
 - [x] **submit(selector)** — `form.requestSubmit()`

--- a/crates/lightbrowse-cdp/src/lib.rs
+++ b/crates/lightbrowse-cdp/src/lib.rs
@@ -1065,8 +1065,7 @@ impl CdpBackend {
     /// Click at raw viewport coordinates (CSS px, top-left origin) — the
     /// "human pointing" action for SoM/vision agents. Dispatches a real
     /// mouseMoved → pressed → released sequence at the given point.
-    pub async fn click_at(&self, x: f64, y: f64, session: Option<&str>) -> Result<Value> {
-        let (sid, active) = self.active_page(session).await?;
+    pub async fn click_at(&self, x: f64, y: f64, session: Option<&str>) -> Result<Value> {        let (sid, active) = self.active_page(session).await?;
         if x < 0.0 || y < 0.0 {
             return Ok(json!({ "ok": false, "reason": "coordinates must be >= 0" }));
         }
@@ -1221,6 +1220,79 @@ impl CdpBackend {
             ms: None,
         });
         Ok(json!({ "ok": true, "key": key }))
+    }
+
+    /// One-call login: detect username + password fields on the CURRENT page
+    /// (direct JS pass — depth-independent, unlike the snapshot tree), fill
+    /// both, and submit (Enter on the password field). Returns what was
+    /// filled and where.
+    pub async fn fill_login(
+        &self,
+        username: &str,
+        password: &str,
+        session: Option<&str>,
+    ) -> Result<Value> {
+        let expr = r#"(() => {
+  const inputs = Array.from(document.querySelectorAll('input'));
+  const editable = (i) => {
+    const t = (i.type || 'text').toLowerCase();
+    return !['hidden','checkbox','radio','submit','button','image','reset','file'].includes(t);
+  };
+  const pass = inputs.find(i => (i.type || '').toLowerCase() === 'password');
+  const hint = (i) => (i.name || '') + ' ' + (i.placeholder || '') + ' ' + (i.id || '');
+  const user = inputs.find(i => editable(i) && i !== pass
+      && /(user|login|email|mail|account|username|t\u00ean|t\u00e0i kho\u1ea3n|\u0111\u0103ng nh\u1eadp)/i.test(hint(i)))
+    || inputs.find(i => editable(i) && i !== pass);
+  const css = (el) => {
+    if (!el) return null;
+    if (el.id) return '#' + CSS.escape(el.id);
+    if (el.name) return el.tagName.toLowerCase() + '[name="' + CSS.escape(el.name) + '"]';
+    // nth-of-type path from body
+    const parts = []; let e = el;
+    while (e && e !== document.documentElement) {
+      const sib = Array.from(e.parentElement ? e.parentElement.children : []).filter(c => c.tagName === e.tagName);
+      const idx = sib.indexOf(e) + 1;
+      parts.unshift(e.tagName.toLowerCase() + ':nth-of-type(' + idx + ')');
+      e = e.parentElement;
+    }
+    return parts.join(' > ');
+  };
+  return JSON.stringify({pass: css(pass), user: css(user)});
+})()"#;
+        let v = self.evaluate(expr, session).await?;
+        let raw = v.as_str().unwrap_or("{}");
+        let parsed: Value = serde_json::from_str(raw)
+            .map_err(|e| Error::Parse(format!("fill_login detect parse: {e}")))?;
+        let pass_sel = parsed.get("pass").and_then(|s| s.as_str()).map(|s| s.to_string());
+        let user_sel = parsed.get("user").and_then(|s| s.as_str()).map(|s| s.to_string());
+
+        let Some(pass_sel) = pass_sel else {
+            return Ok(json!({ "ok": false, "reason": "no password field found (input[type=password])" }));
+        };
+        let Some(user_sel) = user_sel else {
+            return Ok(json!({ "ok": false, "reason": "no username field found" }));
+        };
+
+        let mut filled = Vec::new();
+        let u = self.type_text(&user_sel, username, session).await?;
+        filled.push(json!({ "field": "username", "selector": user_sel, "ok": u.get("ok") }));
+        if u.get("ok").and_then(|v| v.as_bool()) != Some(true) {
+            return Ok(json!({ "ok": false, "reason": "username fill failed", "filled": filled }));
+        }
+        let p = self.type_text(&pass_sel, password, session).await?;
+        filled.push(json!({ "field": "password", "selector": pass_sel, "ok": p.get("ok") }));
+        if p.get("ok").and_then(|v| v.as_bool()) != Some(true) {
+            return Ok(json!({ "ok": false, "reason": "password fill failed", "filled": filled }));
+        }
+
+        // Submit: Enter on the (focused) password field.
+        let submitted = self.press_key("Enter", session).await?;
+        Ok(json!({
+            "ok": true,
+            "filled": filled,
+            "submitted": submitted,
+            "note": "credentials are handled by the caller; consider vault:<name>.field to keep secrets out of context",
+        }))
     }
 
     pub async fn submit(&self, selector: &str, session: Option<&str>) -> Result<Value> {

--- a/crates/lightbrowse-cli/src/main.rs
+++ b/crates/lightbrowse-cli/src/main.rs
@@ -145,6 +145,16 @@ enum Cmd {
         #[arg(long)]
         session: Option<String>,
     },
+    /// One-call login: navigate to URL, auto-detect username+password
+    /// fields, fill both, submit.
+    Login {
+        url: String,
+        username: String,
+        password: String,
+        /// Settle wait (ms) after navigate (bot challenges / heavy JS).
+        #[arg(long, default_value_t = 3000)]
+        settle_ms: u64,
+    },
     /// LLM-less extractive summary of a page (top sentences, no API key).
     Summarize {
         url: String,
@@ -460,6 +470,26 @@ async fn main() -> lightbrowse_core::Result<()> {
         }
         Cmd::ClickAt { x, y, session } => {
             let res = cdp.click_at(x, y, session.as_deref()).await?;
+            print_json(&res);
+        }
+        Cmd::Login {
+            url,
+            username,
+            password,
+            settle_ms,
+        } => {
+            lightbrowse_core::service::navigate(
+                &*fetch,
+                Some(&*cdp_trait),
+                &session,
+                &url,
+                Engine::Cdp,
+            )
+            .await?;
+            if settle_ms > 0 {
+                tokio::time::sleep(std::time::Duration::from_millis(settle_ms)).await;
+            }
+            let res = cdp.fill_login(&username, &password, None).await?;
             print_json(&res);
         }
         Cmd::Summarize {

--- a/crates/lightbrowse-core/src/snapshot.rs
+++ b/crates/lightbrowse-core/src/snapshot.rs
@@ -54,6 +54,10 @@ pub struct SnapshotNode {
     /// `name` attribute (inputs).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+    /// `type` attribute (inputs) — lets agents distinguish password/email
+    /// fields in login flows.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_type: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub placeholder: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -298,6 +302,11 @@ fn build_node(elm: &ElementRef, ctx: &mut Ctx, depth: usize) -> Option<SnapshotN
         text,
         href: e.attr("href").map(|s| s.to_string()),
         name: e.attr("name").map(|s| s.to_string()),
+        input_type: if tag == "input" {
+            e.attr("type").map(|s| s.to_string())
+        } else {
+            None
+        },
         placeholder: e.attr("placeholder").map(|s| s.to_string()),
         checked: e
             .attr("checked")
@@ -331,6 +340,7 @@ fn collect_children_only(elm: &ElementRef, ctx: &mut Ctx, depth: usize) -> Optio
             text: String::new(),
             href: None,
             name: None,
+            input_type: None,
             placeholder: None,
             checked: None,
             alt: None,

--- a/crates/lightbrowse-http/src/lib.rs
+++ b/crates/lightbrowse-http/src/lib.rs
@@ -59,6 +59,7 @@ pub fn router(state: AppState) -> Router {
         .route("/v1/runbook/run", axum::routing::post(runbook_run))
         .route("/v1/click", get(click_action))
         .route("/v1/click_at", get(click_at_action))
+        .route("/v1/login", get(login_action))
         .route("/v1/visual_snapshot", get(visual_snapshot))
         .route("/v1/type", get(type_action))
         .route("/v1/submit", get(submit_action))
@@ -692,6 +693,7 @@ fn openapi_spec() -> Value {
             "/v1/screenshot": { "get": { "summary": "Screenshot the active CDP tab", "responses": { "200": {"description": "PNG"} } } },
             "/v1/click": { "get": { "summary": "Click a CSS selector on the active tab", "parameters": [{"name": "selector", "in": "query", "required": true, "schema": {"type": "string"}}], "responses": { "200": {"description": "click result"} } } },
             "/v1/click_at": { "get": { "summary": "Click at viewport coordinates (CSS px) — the human-pointing action for SoM/vision", "parameters": [{"name": "x", "in": "query", "required": true, "schema": {"type": "number"}}, {"name": "y", "in": "query", "required": true, "schema": {"type": "number"}}], "responses": { "200": {"description": "click result"} } } },
+            "/v1/login": { "get": { "summary": "One-call login: auto-detect username+password fields on the active tab, fill both, submit", "parameters": [{"name": "username", "in": "query", "required": true, "schema": {"type": "string"}}, {"name": "password", "in": "query", "required": true, "schema": {"type": "string"}}], "responses": { "200": {"description": "fill result"} } } },
             "/v1/visual_snapshot": { "get": { "summary": "Vision-grounded look: screenshot + Set-of-Mark numbered overlay + uid map (base64 image)", "parameters": [{"name": "max_marks", "in": "query", "schema": {"type": "integer"}}, {"name": "max_nodes", "in": "query", "schema": {"type": "integer"}}], "responses": { "200": {"description": "JSON with image_base64 + map"} } } },
             "/v1/type": { "get": { "summary": "Type text into an input on the active tab", "parameters": [{"name": "selector", "in": "query", "required": true, "schema": {"type": "string"}}, {"name": "text", "in": "query", "required": true, "schema": {"type": "string"}}], "responses": { "200": {"description": "type result"} } } },
             "/v1/tabs": { "get": { "summary": "List open CDP tabs", "responses": { "200": {"description": "tabs"} } } },
@@ -847,6 +849,27 @@ async fn click_action(
         .await
         .map_err(ApiError::from)?;
     Ok(Json(json!({ "selector": q.selector, "result": res })).into_response())
+}
+
+#[derive(Deserialize)]
+struct LoginQuery {
+    username: String,
+    password: String,
+    /// Optional session id.
+    session: Option<String>,
+}
+
+/// One-call login: auto-detect username+password fields, fill both, submit.
+async fn login_action(
+    State(state): State<AppState>,
+    Query(q): Query<LoginQuery>,
+) -> Result<Response, ApiError> {
+    let cdp_session = resolve_cdp_session(&state, q.session.as_deref())?;
+    let res = require_cdp(&state)?
+        .fill_login(&q.username, &q.password, cdp_session.as_deref())
+        .await
+        .map_err(ApiError::from)?;
+    Ok(Json(res).into_response())
 }
 
 #[derive(Deserialize)]

--- a/crates/lightbrowse-mcp/src/lib.rs
+++ b/crates/lightbrowse-mcp/src/lib.rs
@@ -147,7 +147,7 @@ impl McpServer {
                     "serverInfo": {
                         "name": "lightbrowse",
                         "version": env!("CARGO_PKG_VERSION"),
-                        "description": "Featherweight browser MCP. 33 tools in 7 groups: [Read] fetch/extract/snapshot/search/ask — [Act] click/click_at/visual_snapshot/type/submit/press/evaluate/screenshot/page/current on live CDP tabs — [Download] download/downloads — [Research] research/memory/search — [Runbook] trail/clear + runbook/* — [Session] tabs/list + tab/close — [Network] proxy/get + proxy/set + network/capture + cookies — [Vault] vault/set + vault/list + vault/get + vault/delete (encrypted credentials). engine=auto picks fetch first, falls back to headless Chromium; engine=cdp keeps a live tab for actions. visual_snapshot = SoM numbered overlay for human-like vision agents; click_at = coordinate click. Call the 'help' tool for the grouped catalog with use-cases."
+                        "description": "Featherweight browser MCP. 34 tools in 7 groups: [Read] fetch/extract/snapshot/search/ask — [Act] click/click_at/visual_snapshot/type/login/submit/press/evaluate/screenshot/page/current on live CDP tabs — [Download] download/downloads — [Research] research/memory/search — [Runbook] trail/clear + runbook/* — [Session] tabs/list + tab/close — [Network] proxy/get + proxy/set + network/capture + cookies — [Vault] vault/set + vault/list + vault/get + vault/delete (encrypted credentials). engine=auto picks fetch first, falls back to headless Chromium; engine=cdp keeps a live tab for actions. visual_snapshot = SoM numbered overlay for human-like vision agents; click_at = coordinate click; login = one-call username+password fill. Call the 'help' tool for the grouped catalog with use-cases."
                     }
                 }
             })),
@@ -326,7 +326,7 @@ impl McpServer {
                 }
             }
             "help" => Ok(pretty(&json!({
-                "about": "lightbrowse — featherweight browser MCP. 33 tools in 7 groups.",
+                "about": "lightbrowse — featherweight browser MCP. 34 tools in 7 groups.",
                 "workflow": [
                     "1. navigate (engine=auto for plain pages, engine=cdp for JS/login-heavy apps)",
                     "2. snapshot / extract / ask to understand the page",
@@ -344,7 +344,7 @@ impl McpServer {
                     {
                         "tag": "[Act]",
                         "when": "operate on a live engine=cdp tab (login forms, buttons, JS state)",
-                        "tools": ["click", "click_at", "visual_snapshot", "type", "submit", "press", "evaluate", "screenshot", "page/current"]
+                        "tools": ["click", "click_at", "visual_snapshot", "type", "login", "submit", "press", "evaluate", "screenshot", "page/current"]
                     },
                     {
                         "tag": "[Research]",
@@ -776,6 +776,17 @@ impl McpServer {
                     .await
                     .map_err(|e| e.to_string())?;
                 Ok(pretty(&json!({ "selector": selector, "result": res })))
+            }
+            "login" => {
+                let username = req_str(args, "username")?;
+                let password = req_str(args, "password")?;
+                let cdp = require_cdp(&s)?;
+                let session = opt_str(args, "session");
+                let res = cdp
+                    .fill_login(&username, &password, session.as_deref())
+                    .await
+                    .map_err(|e| e.to_string())?;
+                Ok(pretty(&res))
             }
             "submit" => {
                 let selector = req_str(args, "selector")?;
@@ -1244,6 +1255,19 @@ fn tools_schema() -> Vec<Value> {
             }
         }),
         json!({
+            "name": "login",
+            "description": "ONE-CALL login: detect username+password fields on the current page, fill both, submit. Returns which fields were filled. Password may reference the vault as vault:<name>.field (resolved server-side, never in context).",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "username": { "type": "string", "description": "username / email / phone" },
+                    "password": { "type": "string", "description": "password or vault:<name>.field" },
+                    "session": { "type": "string", "description": "optional session id" }
+                },
+                "required": ["username", "password"]
+            }
+        }),
+        json!({
             "name": "type",
             "description": "Type text into an input/textarea on the ACTIVE CDP tab (React-compatible events).",
             "inputSchema": {
@@ -1395,6 +1419,7 @@ fn tools_schema() -> Vec<Value> {
         ("click_at", "[Act]"),
         ("visual_snapshot", "[Act]"),
         ("type", "[Act]"),
+        ("login", "[Act]"),
         ("submit", "[Act]"),
         ("press", "[Act]"),
         ("evaluate", "[Act]"),


### PR DESCRIPTION
## What

Filling a login form used to need two `type` calls (one per field). Now it is ONE call:

- `fill_login` (CDP): **direct JS detection** of username+password fields — depth-independent, unlike the snapshot-tree walk (voz.vn login fields sit **15 levels deep**, beyond max_depth 12 — found via live debugging)
- `snapshot`: nodes now carry `input_type` (distinguish password/email/text fields)
- Exposed as MCP `login`, HTTP `/v1/login`, CLI `login <url> <user> <pass>` (+ `--settle-ms` for bot challenges)
- Password may reference the vault: `vault:<name>.field` — resolved by the caller, secrets never in context

## Live verification (voz.vn/login)

```
login: ok: True | filled: [username, password]
after submit: url -> https://voz.vn/login/login   # real POST with values
```

clippy clean, 13 test suites pass.