### PR TITLE
feat: fill_form — one-call form/survey filler like a human (register/survey/checkout)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -112,6 +112,14 @@
       username+password fields (depth-independent), fill both, Enter to submit
       (MCP `login` / HTTP `/v1/login` / CLI `login <url> <user> <pass>`;
       secrets can reference the vault as `vault:<name>.field`)
+- [x] **fill_form(values, auto, submit)** — ONE-CALL form/survey filler like a
+      human: enumerates every editable field (inputs/selects/textareas/
+      checkboxes/radios with labels), matches caller values by label/name/id/
+      placeholder, auto-generates test data for the rest (VN-aware: tên, sđt,
+      tuổi, quốc gia…), fills via real input events, optional submit button
+      detection (MCP `fill_form` / HTTP `POST /v1/form/fill` / CLI
+      `fill-form <url> --values '{...}'`). Live-verified on a 11-field
+      registration form — all filled in one call
 - [x] **type(selector, text)** — CDP `Input.insertText` (real keyboard events)
 - [x] **press(key)** — `Input.dispatchKeyEvent` (Enter/Tab/Backspace/...)
 - [x] **submit(selector)** — `form.requestSubmit()`

--- a/crates/lightbrowse-cdp/src/lib.rs
+++ b/crates/lightbrowse-cdp/src/lib.rs
@@ -1295,6 +1295,202 @@ impl CdpBackend {
         }))
     }
 
+    /// Generic form/survey filler — the "human fills a form" action.
+    ///
+    /// Enumerates every editable field on the page (inputs, selects,
+    /// textareas, checkboxes, radios) with labels, then:
+    /// 1. matches caller-provided `values` (key = label / name / id / placeholder),
+    /// 2. auto-generates sensible test data for the rest (`auto: true`),
+    /// 3. fills everything and optionally submits.
+    ///
+    /// `values` is a JSON object, e.g. `{"email": "a@b.com", "Họ tên": "A B"}`.
+    pub async fn fill_form(
+        &self,
+        values: &serde_json::Map<String, Value>,
+        auto: bool,
+        submit: bool,
+        session: Option<&str>,
+    ) -> Result<Value> {
+        // ── 1. Enumerate editable fields (depth-independent JS pass).
+        let enum_js = r#"(() => {
+  const out = [];
+  document.querySelectorAll('input, select, textarea').forEach((el) => {
+    const tag = el.tagName.toLowerCase();
+    const t = tag === 'select' ? 'select' : tag === 'textarea' ? 'textarea' : (el.type || 'text').toLowerCase();
+    if (['hidden','submit','button','image','reset','file'].includes(t)) return;
+    if (el.disabled || el.readOnly) return;
+    const label = (el.labels && el.labels.length ? el.labels[0].textContent : (el.closest('label') || {}).textContent || '').trim().replace(/\s+/g, ' ').slice(0, 80);
+    let css = null;
+    if (el.id) css = '#' + CSS.escape(el.id);
+    else if (el.name) css = tag + '[name="' + CSS.escape(el.name) + '"]';
+    else if (el.type === 'checkbox' || el.type === 'radio') return;
+    if (!css) return;
+    out.push({
+      tag, type: t, name: el.name || '', id: el.id || '', placeholder: el.placeholder || '',
+      label, required: !!el.required, checked: !!(el.checked),
+      options: t === 'select' ? Array.from(el.options).filter(o => o.value !== '').map(o => o.textContent.trim().replace(/\s+/g,' ').slice(0, 40)) : [],
+      css
+    });
+  });
+  return JSON.stringify(out);
+})()"#;
+        let v = self.evaluate(enum_js, session).await?;
+        let raw = v.as_str().unwrap_or("[]");
+        let fields: Vec<Value> = serde_json::from_str(raw)
+            .map_err(|e| Error::Parse(format!("fill_form enumerate parse: {e}")))?;
+
+        // ── 2. Build match keys (normalized) for caller values.
+        let norm = |s: &str| -> String {
+            s.to_lowercase().trim().trim_end_matches(':').to_string()
+        };
+        let mut used = std::collections::HashSet::new();
+        let mut filled = Vec::new();
+        let mut unmatched_user_keys = Vec::new();
+
+        for f in &fields {
+            let ftype = f.get("type").and_then(|x| x.as_str()).unwrap_or("text");
+            let name = f.get("name").and_then(|x| x.as_str()).unwrap_or("");
+            let id = f.get("id").and_then(|x| x.as_str()).unwrap_or("");
+            let placeholder = f.get("placeholder").and_then(|x| x.as_str()).unwrap_or("");
+            let label = f.get("label").and_then(|x| x.as_str()).unwrap_or("");
+            let css = f.get("css").and_then(|x| x.as_str()).unwrap_or("").to_string();
+
+            let keys: Vec<String> = [label, name, id, placeholder]
+                .iter()
+                .filter(|s| !s.is_empty())
+                .map(|s| norm(s))
+                .collect();
+
+            // a) explicit value match (exact then substring)
+            let mut value: Option<(&str, &str)> = None; // (user_key, value)
+            'outer: for (uk, uv) in values {
+                let un = norm(uk);
+                for k in &keys {
+                    if *k == un {
+                        value = Some((uk, uv.as_str().unwrap_or("")));
+                        break 'outer;
+                    }
+                }
+            }
+            if value.is_none() {
+                'outer2: for (uk, uv) in values {
+                    let un = norm(uk);
+                    for k in &keys {
+                        if k.contains(&un) || un.contains(k) {
+                            value = Some((uk, uv.as_str().unwrap_or("")));
+                            break 'outer2;
+                        }
+                    }
+                }
+            }
+
+            // b) auto-generate for unmatched fields
+            let options: Vec<Value> = f
+                .get("options")
+                .and_then(|o| o.as_array())
+                .cloned()
+                .unwrap_or_default();
+            let generated = if value.is_none() && auto {
+                Some(auto_value(ftype, &norm(&format!("{name} {label} {placeholder}")), &rand_suffix(), &options))
+            } else {
+                None
+            };
+
+            let val = match (value, generated) {
+                (Some((uk, uv)), _) => {
+                    used.insert(uk.to_string());
+                    uv.to_string()
+                }
+                (None, Some(g)) => g,
+                (None, None) => {
+                    if value.is_none() {
+                        // user key never matched anything
+                    }
+                    continue;
+                }
+            };
+
+            // ── 3. Fill by type.
+            let ok = match ftype {
+                "checkbox" => {
+                    let target = val.eq_ignore_ascii_case("true") || val.eq_ignore_ascii_case("yes") || val == "1" || val.is_empty();
+                    if target != f.get("checked").and_then(|c| c.as_bool()).unwrap_or(false) {
+                        self.click(&css, session).await.map(|r| r.get("ok").and_then(|o| o.as_bool()).unwrap_or(false)).unwrap_or(false)
+                    } else { true }
+                }
+                "radio" => {
+                    self.click(&css, session).await.map(|r| r.get("ok").and_then(|o| o.as_bool()).unwrap_or(false)).unwrap_or(false)
+                }
+                "select" => {
+                    let set_js = format!(
+                        "(() => {{ const el = document.querySelector({sel}); if (!el) return false;                          const want = {want}; const opt = Array.from(el.options).find(o => o.value === want || o.textContent.trim() === want);                          if (!opt) return false; el.value = opt.value;                          el.dispatchEvent(new Event('change', {{bubbles: true}})); return true; }})()",
+                        sel = serde_json::to_string(&css).unwrap_or_default(),
+                        want = serde_json::to_string(&val).unwrap_or_default()
+                    );
+                    self.evaluate(&set_js, session).await
+                        .map(|r| r.as_bool().unwrap_or(false)).unwrap_or(false)
+                }
+                "date" | "time" | "month" => {
+                    let set_js = format!(
+                        "(() => {{ const el = document.querySelector({sel}); if (!el) return false;                          el.value = {want}; el.dispatchEvent(new Event('input', {{bubbles: true}}));                          el.dispatchEvent(new Event('change', {{bubbles: true}})); return el.value === {want}; }})()",
+                        sel = serde_json::to_string(&css).unwrap_or_default(),
+                        want = serde_json::to_string(&val).unwrap_or_default()
+                    );
+                    self.evaluate(&set_js, session).await
+                        .map(|r| r.as_bool().unwrap_or(false)).unwrap_or(false)
+                }
+                _ => {
+                    let typed = self.type_text(&css, &val, session).await?;
+                    typed.get("ok").and_then(|o| o.as_bool()).unwrap_or(false)
+                }
+            };
+
+            filled.push(json!({
+                "field": if !label.is_empty() { label } else if !name.is_empty() { name } else { id },
+                "key": value.map(|(k, _)| k).unwrap_or("(auto)"),
+                "type": ftype,
+                "value": val,
+                "ok": ok,
+            }));
+        }
+
+        for (uk, _) in values {
+            if !used.contains(uk) {
+                unmatched_user_keys.push(uk.clone());
+            }
+        }
+
+        // ── 4. Optional submit.
+        let submitted = if submit {
+            let sub_js = r#"(() => {
+  const btn = Array.from(document.querySelectorAll('button[type=submit], input[type=submit], button'))
+    .find(b => /submit|login|register|sign\s*up|create|save|đăng ký|đăng nhập|đồng ý|tiếp tục|gửi/i.test((b.textContent || b.value || '')));
+  if (btn) { btn.click(); return 'click:' + (btn.textContent || btn.value || '').trim().slice(0, 30); }
+  return null;
+})()"#;
+            let r = self.evaluate(sub_js, session).await;
+            match r {
+                Ok(rr) => match rr.as_str() {
+                    Some(s) if !s.is_empty() && !s.starts_with("null") => json!(s),
+                    _ => {
+                        let k = self.press_key("Enter", session).await?;
+                        json!(k.get("ok"))
+                    }
+                },
+                Err(_) => json!("none"),
+            }
+        } else {
+            json!(false)
+        };
+
+        Ok(json!({
+            "ok": true,
+            "filled": filled,
+            "unmatched_values": unmatched_user_keys,
+            "submitted": submitted,
+        }))
+    }
+
     pub async fn submit(&self, selector: &str, session: Option<&str>) -> Result<Value> {
         let sel = serde_json::to_string(selector).map_err(|e| Error::Parse(e.to_string()))?;
         let (_, active) = self.active_page(session).await?;
@@ -2176,6 +2372,70 @@ async fn stealth_setup(
 }
 
 /// One-shot JS evaluation on a page websocket (opens + closes its own ws).
+/// Generate a plausible test value for an unmatched form field, based on its
+/// type and normalized name/label/placeholder hints. Vietnamese-aware.
+fn auto_value(ftype: &str, hints: &str, rnd: &str, options: &[Value]) -> String {
+    match ftype {
+        "email" => format!("lb.{rnd}@test.dev"),
+        "password" => format!("Passw0rd!{rnd}"),
+        "tel" | "phone" => {
+            // digits-only suffix (rnd is alphanumeric — filter to digits)
+            let digits: String = rnd.chars().filter(|c| c.is_ascii_digit()).take(8).collect();
+            format!("09{digits}")
+        }
+        "number" => {
+            if hints.contains("tuoi") || hints.contains("age") { "25".into() }
+            else if hints.contains("so luong") || hints.contains("quantity") { "2".into() }
+            else { "42".into() }
+        }
+        "date" => "2026-08-30".into(),
+        "select" => options
+            .first()
+            .and_then(|o| o.as_str())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| "1".into()),
+        "checkbox" | "radio" => "true".into(),
+        _ => {
+            if hints.contains("email") { format!("lb.{rnd}@test.dev") }
+            else if hints.contains("user") || hints.contains("tai khoan") || hints.contains("ten dang nhap") {
+                format!("lbuser{rnd}")
+            } else if hints.contains("pass") || hints.contains("mat khau") {
+                format!("Passw0rd!{rnd}")
+            } else if hints.contains("ho") || hints.contains("ten") || hints.contains("name") {
+                format!("Nguyen Van {rnd}")
+            } else if hints.contains("sdt") || hints.contains("phone") || hints.contains("dien thoai") {
+                let digits: String = rnd.chars().filter(|c| c.is_ascii_digit()).take(8).collect();
+                format!("09{digits}")
+            } else if hints.contains("dia chi") || hints.contains("address") || hints.contains("city") || hints.contains("thanh pho") {
+                "Ha Noi".into()
+            } else if hints.contains("birth") || hints.contains("ngay sinh") || hints.contains("namsinh") {
+                "1991-04-05".into()
+            } else if hints.contains("gioi tinh") || hints.contains("gender") {
+                "Nam".into()
+            } else if ftype == "textarea" {
+                "Test content generated by lightbrowse form filler.".into()
+            } else {
+                format!("test{rnd}")
+            }
+        }
+    }
+}
+
+/// Short pseudo-random alphanumeric suffix for generated values
+/// (time + thread-id hash — no extra crate needed).
+fn rand_suffix() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let t = SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_nanos()).unwrap_or(0);
+    let mut seed = t as u64 ^ std::process::id() as u64;
+    let mut out = String::with_capacity(10);
+    for _ in 0..10 {
+        seed = seed.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        let c = ((seed >> 33) % 36) as u8;
+        out.push(if c < 10 { (b'0' + c) as char } else { (b'a' + c - 10) as char });
+    }
+    out
+}
+
 async fn evaluate_js(ws_url: &str, expression: &str) -> Result<Value> {
     let (mut ws, _) = tokio_tungstenite::connect_async(ws_url)
         .await

--- a/crates/lightbrowse-cli/src/main.rs
+++ b/crates/lightbrowse-cli/src/main.rs
@@ -155,6 +155,23 @@ enum Cmd {
         #[arg(long, default_value_t = 3000)]
         settle_ms: u64,
     },
+    /// One-call form/survey fill: navigate, fill fields like a human
+    /// (values by label/name + auto test data), optionally submit.
+    FillForm {
+        url: String,
+        /// JSON map of field label/name -> value, e.g. '{"email":"a@b.com"}'
+        #[arg(long)]
+        values: Option<String>,
+        /// Fill unmatched fields with generated test data (default true).
+        #[arg(long)]
+        no_auto: bool,
+        /// Click the submit/register button after filling.
+        #[arg(long)]
+        submit: bool,
+        /// Settle wait (ms) after navigate.
+        #[arg(long, default_value_t = 3000)]
+        settle_ms: u64,
+    },
     /// LLM-less extractive summary of a page (top sentences, no API key).
     Summarize {
         url: String,
@@ -490,6 +507,34 @@ async fn main() -> lightbrowse_core::Result<()> {
                 tokio::time::sleep(std::time::Duration::from_millis(settle_ms)).await;
             }
             let res = cdp.fill_login(&username, &password, None).await?;
+            print_json(&res);
+        }
+        Cmd::FillForm {
+            url,
+            values,
+            no_auto,
+            submit,
+            settle_ms,
+        } => {
+            lightbrowse_core::service::navigate(
+                &*fetch,
+                Some(&*cdp_trait),
+                &session,
+                &url,
+                Engine::Cdp,
+            )
+            .await?;
+            if settle_ms > 0 {
+                tokio::time::sleep(std::time::Duration::from_millis(settle_ms)).await;
+            }
+            let values: serde_json::Map<String, Value> = match &values {
+                Some(raw) => serde_json::from_str(raw)
+                    .map_err(|e| lightbrowse_core::Error::Unsupported(format!("values JSON: {e}")))?,
+                None => serde_json::Map::new(),
+            };
+            let res = cdp
+                .fill_form(&values, !no_auto, submit, None)
+                .await?;
             print_json(&res);
         }
         Cmd::Summarize {

--- a/crates/lightbrowse-http/src/lib.rs
+++ b/crates/lightbrowse-http/src/lib.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "512"]
+
 //! HTTP/REST API for lightbrowse.
 //!
 //! Useful for scripting, and for hosting the browser as a microservice that
@@ -60,6 +62,7 @@ pub fn router(state: AppState) -> Router {
         .route("/v1/click", get(click_action))
         .route("/v1/click_at", get(click_at_action))
         .route("/v1/login", get(login_action))
+        .route("/v1/form/fill", axum::routing::post(form_fill))
         .route("/v1/visual_snapshot", get(visual_snapshot))
         .route("/v1/type", get(type_action))
         .route("/v1/submit", get(submit_action))
@@ -694,6 +697,7 @@ fn openapi_spec() -> Value {
             "/v1/click": { "get": { "summary": "Click a CSS selector on the active tab", "parameters": [{"name": "selector", "in": "query", "required": true, "schema": {"type": "string"}}], "responses": { "200": {"description": "click result"} } } },
             "/v1/click_at": { "get": { "summary": "Click at viewport coordinates (CSS px) — the human-pointing action for SoM/vision", "parameters": [{"name": "x", "in": "query", "required": true, "schema": {"type": "number"}}, {"name": "y", "in": "query", "required": true, "schema": {"type": "number"}}], "responses": { "200": {"description": "click result"} } } },
             "/v1/login": { "get": { "summary": "One-call login: auto-detect username+password fields on the active tab, fill both, submit", "parameters": [{"name": "username", "in": "query", "required": true, "schema": {"type": "string"}}, {"name": "password", "in": "query", "required": true, "schema": {"type": "string"}}], "responses": { "200": {"description": "fill result"} } } },
+            "/v1/form/fill": { "post": { "summary": "Fill ANY form/survey in one call: values map + auto test data + optional submit", "requestBody": { "content": { "application/json": { "schema": { "type": "object", "properties": { "values": { "type": "object" }, "auto": { "type": "boolean" }, "submit": { "type": "boolean" } } } } } }, "responses": { "200": {"description": "fill result"} } } },
             "/v1/visual_snapshot": { "get": { "summary": "Vision-grounded look: screenshot + Set-of-Mark numbered overlay + uid map (base64 image)", "parameters": [{"name": "max_marks", "in": "query", "schema": {"type": "integer"}}, {"name": "max_nodes", "in": "query", "schema": {"type": "integer"}}], "responses": { "200": {"description": "JSON with image_base64 + map"} } } },
             "/v1/type": { "get": { "summary": "Type text into an input on the active tab", "parameters": [{"name": "selector", "in": "query", "required": true, "schema": {"type": "string"}}, {"name": "text", "in": "query", "required": true, "schema": {"type": "string"}}], "responses": { "200": {"description": "type result"} } } },
             "/v1/tabs": { "get": { "summary": "List open CDP tabs", "responses": { "200": {"description": "tabs"} } } },
@@ -867,6 +871,35 @@ async fn login_action(
     let cdp_session = resolve_cdp_session(&state, q.session.as_deref())?;
     let res = require_cdp(&state)?
         .fill_login(&q.username, &q.password, cdp_session.as_deref())
+        .await
+        .map_err(ApiError::from)?;
+    Ok(Json(res).into_response())
+}
+
+#[derive(Deserialize)]
+struct FormFillBody {
+    /// field label/name/id/placeholder -> value
+    values: serde_json::Map<String, serde_json::Value>,
+    #[serde(default = "default_true")]
+    auto: bool,
+    #[serde(default)]
+    submit: bool,
+    /// Optional session id.
+    session: Option<String>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+/// Fill any form/survey in one call (values + auto test data + optional submit).
+async fn form_fill(
+    State(state): State<AppState>,
+    Json(body): Json<FormFillBody>,
+) -> Result<Response, ApiError> {
+    let cdp_session = resolve_cdp_session(&state, body.session.as_deref())?;
+    let res = require_cdp(&state)?
+        .fill_form(&body.values, body.auto, body.submit, cdp_session.as_deref())
         .await
         .map_err(ApiError::from)?;
     Ok(Json(res).into_response())

--- a/crates/lightbrowse-mcp/src/lib.rs
+++ b/crates/lightbrowse-mcp/src/lib.rs
@@ -147,7 +147,7 @@ impl McpServer {
                     "serverInfo": {
                         "name": "lightbrowse",
                         "version": env!("CARGO_PKG_VERSION"),
-                        "description": "Featherweight browser MCP. 34 tools in 7 groups: [Read] fetch/extract/snapshot/search/ask — [Act] click/click_at/visual_snapshot/type/login/submit/press/evaluate/screenshot/page/current on live CDP tabs — [Download] download/downloads — [Research] research/memory/search — [Runbook] trail/clear + runbook/* — [Session] tabs/list + tab/close — [Network] proxy/get + proxy/set + network/capture + cookies — [Vault] vault/set + vault/list + vault/get + vault/delete (encrypted credentials). engine=auto picks fetch first, falls back to headless Chromium; engine=cdp keeps a live tab for actions. visual_snapshot = SoM numbered overlay for human-like vision agents; click_at = coordinate click; login = one-call username+password fill. Call the 'help' tool for the grouped catalog with use-cases."
+                        "description": "Featherweight browser MCP. 35 tools in 7 groups: [Read] fetch/extract/snapshot/search/ask — [Act] click/click_at/visual_snapshot/type/login/submit/press/evaluate/screenshot/page/current on live CDP tabs — [Download] download/downloads — [Research] research/memory/search — [Runbook] trail/clear + runbook/* — [Session] tabs/list + tab/close — [Network] proxy/get + proxy/set + network/capture + cookies — [Vault] vault/set + vault/list + vault/get + vault/delete (encrypted credentials). engine=auto picks fetch first, falls back to headless Chromium; engine=cdp keeps a live tab for actions. visual_snapshot = SoM numbered overlay for human-like vision agents; click_at = coordinate click; login = one-call username+password fill; fill_form = one-call any-form/survey fill (auto test data). Call the 'help' tool for the grouped catalog with use-cases."
                     }
                 }
             })),
@@ -326,7 +326,7 @@ impl McpServer {
                 }
             }
             "help" => Ok(pretty(&json!({
-                "about": "lightbrowse — featherweight browser MCP. 34 tools in 7 groups.",
+                "about": "lightbrowse — featherweight browser MCP. 35 tools in 7 groups.",
                 "workflow": [
                     "1. navigate (engine=auto for plain pages, engine=cdp for JS/login-heavy apps)",
                     "2. snapshot / extract / ask to understand the page",
@@ -344,7 +344,7 @@ impl McpServer {
                     {
                         "tag": "[Act]",
                         "when": "operate on a live engine=cdp tab (login forms, buttons, JS state)",
-                        "tools": ["click", "click_at", "visual_snapshot", "type", "login", "submit", "press", "evaluate", "screenshot", "page/current"]
+                        "tools": ["click", "click_at", "visual_snapshot", "type", "login", "fill_form", "submit", "press", "evaluate", "screenshot", "page/current"]
                     },
                     {
                         "tag": "[Research]",
@@ -784,6 +784,28 @@ impl McpServer {
                 let session = opt_str(args, "session");
                 let res = cdp
                     .fill_login(&username, &password, session.as_deref())
+                    .await
+                    .map_err(|e| e.to_string())?;
+                Ok(pretty(&res))
+            }
+            "fill_form" => {
+                let values = args
+                    .get("values")
+                    .and_then(|v| v.as_object())
+                    .cloned()
+                    .unwrap_or_default();
+                let auto = args
+                    .get("auto")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(true);
+                let submit = args
+                    .get("submit")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                let cdp = require_cdp(&s)?;
+                let session = opt_str(args, "session");
+                let res = cdp
+                    .fill_form(&values, auto, submit, session.as_deref())
                     .await
                     .map_err(|e| e.to_string())?;
                 Ok(pretty(&res))
@@ -1255,6 +1277,20 @@ fn tools_schema() -> Vec<Value> {
             }
         }),
         json!({
+            "name": "fill_form",
+            "description": "Fill ANY form/survey like a human, in one call: enumerates all editable fields (inputs/selects/textareas/checkboxes/radios with labels), matches your values by label/name/id/placeholder, auto-generates sensible test data for the rest (auto=true), optionally submits. values is a JSON object of field label-or-name to value.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "values": { "type": "object", "description": "field label/name/id/placeholder -> value", "additionalProperties": { "type": "string" } },
+                    "auto": { "type": "boolean", "default": true, "description": "fill unmatched fields with generated test data" },
+                    "submit": { "type": "boolean", "default": false, "description": "click the submit/register button after filling" },
+                    "session": { "type": "string", "description": "optional session id" }
+                },
+                "required": ["values"]
+            }
+        }),
+        json!({
             "name": "login",
             "description": "ONE-CALL login: detect username+password fields on the current page, fill both, submit. Returns which fields were filled. Password may reference the vault as vault:<name>.field (resolved server-side, never in context).",
             "inputSchema": {
@@ -1420,6 +1456,7 @@ fn tools_schema() -> Vec<Value> {
         ("visual_snapshot", "[Act]"),
         ("type", "[Act]"),
         ("login", "[Act]"),
+        ("fill_form", "[Act]"),
         ("submit", "[Act]"),
         ("press", "[Act]"),
         ("evaluate", "[Act]"),


### PR DESCRIPTION
## What

Extends the one-call idea beyond login: **fill ANY form/survey like a human** — the agent looks at the form, understands each field (label/name/type), fills everything in ONE call, optionally submits.

- **Enumerate**: direct JS pass over input/select/textarea/checkbox/radio with labels — depth-independent (voz login fields were 15 levels deep; tree walk can’t be trusted for forms)
- **Match**: caller `values` by label / name / id / placeholder (exact → fuzzy)
- **Auto-fill**: VN-aware generated test data for the rest (tên, tài khoản, sđt digits-only, tuổi, ngày sinh, quốc gia, mật khẩu, giới thiệu…)
- **Fill engine**: real input events (type_text for text; JS setters for date/select/checkbox/radio)
- **Submit**: detects submit/register/đăng ký/tiếp tục button, else Enter
- Exposed: MCP `fill_form` · HTTP `POST /v1/form/fill` · CLI `fill-form <url> --values u007b...u007d`

## Live verification — 11-field VN registration form (local, deterministic)

```
fullname: Nguyen Van A   (provided)
username: lbuserw7gba1e0sd (auto)
email:    a@test.dev      (provided)
phone:    098568          (auto, digits-only)
password: Passw0rd!...    (auto)
dob:      2026-08-30      (auto, date via JS setter)
age:      25              (auto)
gender:   nam             (auto, radio)
country:  vn              (auto, select first option)
bio:      Test content... (auto)
agree:    true            (auto, checkbox)
```

clippy clean, 13 test suites pass.