### PR TITLE
feat: login auto-save to vault on detected success (+ login_success_probe)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1491,6 +1491,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]
@@ -1556,6 +1557,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -1571,6 +1573,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/crates/lightbrowse-cdp/src/lib.rs
+++ b/crates/lightbrowse-cdp/src/lib.rs
@@ -1491,6 +1491,44 @@ impl CdpBackend {
         }))
     }
 
+    /// Probe whether a login attempt actually succeeded: page left the login
+    /// URL and/or a logged-in indicator (logout link, user menu, avatar)
+    /// appeared. Heuristic — used to decide auto-save to the vault.
+    pub async fn login_success_probe(&self, session: Option<&str>) -> Result<Value> {
+        let expr = r#"(() => {
+  const url = location.href;
+  const onLoginPage = /login|log\s*in|signin|sign\s*in|dang\s*nhap|\u0111\u0103ng\s*nh\u1eadp/i.test(url);
+  const loginLink = document.querySelector('a[href*="login" i], a[href*="log-in" i], a[href*="signin" i], a[href*="sign-in" i]');
+  const logout = document.querySelector('a[href*="logout" i], a[href*="log-out" i], [data-xf-click="logout"]');
+  const userMenu = document.querySelector('.p-navgroup-link--account, .p-navEl--user, [data-user="1"], .navbar-user, .header-account, [class*="account"]');
+  const avatar = document.querySelector('.avatar, img[alt*="avatar" i], .user-avatar');
+  return JSON.stringify({
+    url,
+    on_login_page: !!onLoginPage,
+    has_login_link: !!loginLink,
+    has_logout: !!logout,
+    has_user_menu: !!userMenu,
+    has_avatar: !!avatar
+  });
+})()"#;
+        let v = self.evaluate(expr, session).await?;
+        let raw = v.as_str().unwrap_or("{}");
+        let parsed: Value = serde_json::from_str(raw)
+            .map_err(|e| Error::Parse(format!("login probe parse: {e}")))?;
+        let on_login = parsed.get("on_login_page").and_then(|b| b.as_bool()).unwrap_or(true);
+        let logged_in = parsed.get("has_logout").and_then(|b| b.as_bool()).unwrap_or(false)
+            || parsed.get("has_user_menu").and_then(|b| b.as_bool()).unwrap_or(false);
+        let url = parsed.get("url").and_then(|s| s.as_str()).unwrap_or("").to_string();
+        let detected = !on_login || logged_in;
+        Ok(json!({
+            "detected": detected,
+            "on_login_page": on_login,
+            "has_logout": parsed.get("has_logout"),
+            "has_user_menu": parsed.get("has_user_menu"),
+            "url": url,
+        }))
+    }
+
     pub async fn submit(&self, selector: &str, session: Option<&str>) -> Result<Value> {
         let sel = serde_json::to_string(selector).map_err(|e| Error::Parse(e.to_string()))?;
         let (_, active) = self.active_page(session).await?;

--- a/crates/lightbrowse-cli/Cargo.toml
+++ b/crates/lightbrowse-cli/Cargo.toml
@@ -21,5 +21,6 @@ lightbrowse-cdp = { workspace = true }
 tokio = { workspace = true }
 clap = { workspace = true }
 serde_json = { workspace = true }
+url = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/lightbrowse-cli/src/main.rs
+++ b/crates/lightbrowse-cli/src/main.rs
@@ -146,7 +146,7 @@ enum Cmd {
         session: Option<String>,
     },
     /// One-call login: navigate to URL, auto-detect username+password
-    /// fields, fill both, submit.
+    /// fields, fill both, submit. Auto-saves to the vault on detected success.
     Login {
         url: String,
         username: String,
@@ -154,6 +154,12 @@ enum Cmd {
         /// Settle wait (ms) after navigate (bot challenges / heavy JS).
         #[arg(long, default_value_t = 3000)]
         settle_ms: u64,
+        /// Disable auto-save to the encrypted vault.
+        #[arg(long)]
+        no_save: bool,
+        /// Vault entry name (default: hostname).
+        #[arg(long)]
+        vault_name: Option<String>,
     },
     /// One-call form/survey fill: navigate, fill fields like a human
     /// (values by label/name + auto test data), optionally submit.
@@ -494,6 +500,8 @@ async fn main() -> lightbrowse_core::Result<()> {
             username,
             password,
             settle_ms,
+            no_save,
+            vault_name,
         } => {
             lightbrowse_core::service::navigate(
                 &*fetch,
@@ -507,7 +515,47 @@ async fn main() -> lightbrowse_core::Result<()> {
                 tokio::time::sleep(std::time::Duration::from_millis(settle_ms)).await;
             }
             let res = cdp.fill_login(&username, &password, None).await?;
-            print_json(&res);
+            if res.get("ok").and_then(|v| v.as_bool()) == Some(true) && !no_save {
+                tokio::time::sleep(std::time::Duration::from_millis(2500)).await;
+                let probe = cdp.login_success_probe(None).await?;
+                if probe
+                    .get("detected")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false)
+                {
+                    let cur_url = probe.get("url").and_then(|v| v.as_str()).unwrap_or("");
+                    let name = vault_name.clone().unwrap_or_else(|| {
+                        url::Url::parse(cur_url)
+                            .ok()
+                            .and_then(|u| u.host_str().map(|h| h.to_string()))
+                            .unwrap_or_else(|| "saved-login".into())
+                    });
+                    let vault = lightbrowse_core::vault::Vault::open(Default::default())
+                        .map_err(lightbrowse_core::Error::Parse)?;
+                    vault
+                        .set(
+                            &name,
+                            lightbrowse_core::vault::VaultEntry {
+                                url: cur_url.to_string(),
+                                username: username.clone(),
+                                password: password.clone(),
+                                extra: json!({"source": "login-auto-save"}),
+                                updated_at: std::time::SystemTime::now()
+                                    .duration_since(std::time::UNIX_EPOCH)
+                                    .map(|d| d.as_secs())
+                                    .unwrap_or(0),
+                            },
+                        )
+                        .map_err(lightbrowse_core::Error::Parse)?;
+                    print_json(&json!({
+                        "login": res,
+                        "probe": probe,
+                        "vault_saved": name,
+                    }));
+                    return Ok(());
+                }
+            }
+            print_json(&json!({ "login": res }));
         }
         Cmd::FillForm {
             url,
@@ -725,6 +773,9 @@ async fn main() -> lightbrowse_core::Result<()> {
                 engine,
                 config: Arc::new(config),
                 memory: Arc::new(memory),
+                vault: lightbrowse_core::vault::Vault::open(Default::default())
+                    .ok()
+                    .map(Arc::new),
             };
             lightbrowse_http::serve(&format!("{host}:{port}"), state).await?;
         }

--- a/crates/lightbrowse-http/Cargo.toml
+++ b/crates/lightbrowse-http/Cargo.toml
@@ -16,5 +16,6 @@ tokio = { workspace = true }
 axum = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+url = { workspace = true }
 base64 = "0.22"
 tracing = { workspace = true }

--- a/crates/lightbrowse-http/src/lib.rs
+++ b/crates/lightbrowse-http/src/lib.rs
@@ -41,6 +41,8 @@ pub struct AppState {
     pub engine: Engine,
     pub config: Arc<Config>,
     pub memory: Arc<MemoryStore>,
+    /// Encrypted credential vault (None when unavailable).
+    pub vault: Option<Arc<lightbrowse_core::vault::Vault>>,
 }
 
 pub fn router(state: AppState) -> Router {
@@ -859,21 +861,76 @@ async fn click_action(
 struct LoginQuery {
     username: String,
     password: String,
+    /// Auto-save credentials to the vault on detected login success.
+    #[serde(default = "default_true")]
+    save_vault: bool,
+    /// Vault entry name (default: hostname).
+    vault_name: Option<String>,
     /// Optional session id.
     session: Option<String>,
 }
 
 /// One-call login: auto-detect username+password fields, fill both, submit.
+/// With save_vault=true, auto-saves credentials on detected login success.
 async fn login_action(
     State(state): State<AppState>,
     Query(q): Query<LoginQuery>,
 ) -> Result<Response, ApiError> {
     let cdp_session = resolve_cdp_session(&state, q.session.as_deref())?;
-    let res = require_cdp(&state)?
-        .fill_login(&q.username, &q.password, cdp_session.as_deref())
+    let cdp = require_cdp(&state)?;
+    let mut username = q.username;
+    let mut password = q.password;
+    if let Some(vault) = &state.vault {
+        if password.starts_with("vault:") {
+            password = vault
+                .resolve_ref(&password)
+                .ok_or_else(|| ApiError::internal("unknown vault ref"))?
+                .map_err(ApiError::internal)?;
+        }
+        if username.starts_with("vault:") {
+            username = vault
+                .resolve_ref(&username)
+                .ok_or_else(|| ApiError::internal("unknown vault ref"))?
+                .map_err(ApiError::internal)?;
+        }
+    }
+    let res = cdp
+        .fill_login(&username, &password, cdp_session.as_deref())
         .await
         .map_err(ApiError::from)?;
-    Ok(Json(res).into_response())
+    let mut saved = serde_json::Value::Null;
+    let mut probe = serde_json::Value::Null;
+    if res.get("ok").and_then(|v| v.as_bool()) == Some(true) && q.save_vault {
+        tokio::time::sleep(std::time::Duration::from_millis(2500)).await;
+        probe = cdp
+            .login_success_probe(cdp_session.as_deref())
+            .await
+            .map_err(ApiError::from)?;
+        if probe.get("detected").and_then(|v| v.as_bool()).unwrap_or(false) {
+            let url = probe.get("url").and_then(|v| v.as_str()).unwrap_or("");
+            let name = q.vault_name.clone().unwrap_or_else(|| {
+                url::Url::parse(url)
+                    .ok()
+                    .and_then(|u| u.host_str().map(|h| h.to_string()))
+                    .unwrap_or_else(|| "saved-login".into())
+            });
+            if let Some(vault) = &state.vault {
+                let entry = lightbrowse_core::vault::VaultEntry {
+                    url: url.to_string(),
+                    username: username.clone(),
+                    password: password.clone(),
+                    extra: serde_json::json!({"source": "login-auto-save"}),
+                    updated_at: std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_secs())
+                        .unwrap_or(0),
+                };
+                vault.set(&name, entry).map_err(ApiError::internal)?;
+                saved = json!(name);
+            }
+        }
+    }
+    Ok(Json(json!({ "login": res, "probe": probe, "vault_saved": saved })).into_response())
 }
 
 #[derive(Deserialize)]

--- a/crates/lightbrowse-mcp/Cargo.toml
+++ b/crates/lightbrowse-mcp/Cargo.toml
@@ -15,5 +15,6 @@ lightbrowse-cdp = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+url = { workspace = true }
 tracing = { workspace = true }
 base64 = "0.22"

--- a/crates/lightbrowse-mcp/src/lib.rs
+++ b/crates/lightbrowse-mcp/src/lib.rs
@@ -778,15 +778,90 @@ impl McpServer {
                 Ok(pretty(&json!({ "selector": selector, "result": res })))
             }
             "login" => {
-                let username = req_str(args, "username")?;
-                let password = req_str(args, "password")?;
+                let mut username = req_str(args, "username")?;
+                let mut password = req_str(args, "password")?;
+                let save_vault = args
+                    .get("save_vault")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(true);
+                let vault_name = opt_str(args, "vault_name");
                 let cdp = require_cdp(&s)?;
                 let session = opt_str(args, "session");
+
+                // Resolve vault:<name>.<field> refs server-side so the real
+                // secret is typed AND re-savable, never shown to the LLM.
+                if let Some(vault) = &s.vault {
+                    if password.starts_with("vault:") {
+                        password = match vault.resolve_ref(&password) {
+                            Some(Ok(v)) => v,
+                            Some(Err(e)) => return Err(e),
+                            None => return Err(format!("unknown vault ref: {password}")),
+                        };
+                    }
+                    if username.starts_with("vault:") {
+                        username = match vault.resolve_ref(&username) {
+                            Some(Ok(v)) => v,
+                            Some(Err(e)) => return Err(e),
+                            None => return Err(format!("unknown vault ref: {username}")),
+                        };
+                    }
+                }
+
                 let res = cdp
                     .fill_login(&username, &password, session.as_deref())
                     .await
                     .map_err(|e| e.to_string())?;
-                Ok(pretty(&res))
+                if res.get("ok").and_then(|v| v.as_bool()) != Some(true) {
+                    return Ok(pretty(&res));
+                }
+
+                // Auto-save on detected success.
+                let mut saved = json!(null);
+                let mut probe = json!(null);
+                if save_vault {
+                    tokio::time::sleep(std::time::Duration::from_millis(2500)).await;
+                    probe = cdp
+                        .login_success_probe(session.as_deref())
+                        .await
+                        .map_err(|e| e.to_string())?;
+                    let detected = probe
+                        .get("detected")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false);
+                    if detected {
+                        let url = probe.get("url").and_then(|v| v.as_str()).unwrap_or("");
+                        let name = vault_name.unwrap_or_else(|| {
+                            url::Url::parse(url)
+                                .ok()
+                                .and_then(|u| u.host_str().map(|h| h.to_string()))
+                                .unwrap_or_else(|| "saved-login".into())
+                        });
+                        if let Some(vault) = &s.vault {
+                            let entry = lightbrowse_core::vault::VaultEntry {
+                                url: url.to_string(),
+                                username: username.clone(),
+                                password: password.clone(),
+                                extra: serde_json::json!({"source": "login-auto-save"}),
+                                updated_at: std::time::SystemTime::now()
+                                    .duration_since(std::time::UNIX_EPOCH)
+                                    .map(|d| d.as_secs())
+                                    .unwrap_or(0),
+                            };
+                            match vault.set(&name, entry) {
+                                Ok(()) => saved = json!(name),
+                                Err(e) => return Err(e),
+                            }
+                        } else {
+                            return Err("vault unavailable — start with a vault path".into());
+                        }
+                    }
+                }
+
+                Ok(pretty(&json!({
+                    "login": res,
+                    "probe": probe,
+                    "vault_saved": saved,
+                })))
             }
             "fill_form" => {
                 let values = args
@@ -1292,12 +1367,14 @@ fn tools_schema() -> Vec<Value> {
         }),
         json!({
             "name": "login",
-            "description": "ONE-CALL login: detect username+password fields on the current page, fill both, submit. Returns which fields were filled. Password may reference the vault as vault:<name>.field (resolved server-side, never in context).",
+            "description": "ONE-CALL login: detect username+password fields on the current page, fill both, submit. With save_vault=true (default), waits ~2.5s after submit and AUTO-SAVES credentials to the encrypted vault when login success is detected (page left the login URL / logged-in indicator appeared). Password/username may reference the vault as vault:<name>.field (resolved server-side, never in context).",
             "inputSchema": {
                 "type": "object",
                 "properties": {
-                    "username": { "type": "string", "description": "username / email / phone" },
+                    "username": { "type": "string", "description": "username / email / phone, or vault:<name>.field" },
                     "password": { "type": "string", "description": "password or vault:<name>.field" },
+                    "save_vault": { "type": "boolean", "default": true, "description": "auto-save to vault on detected login success" },
+                    "vault_name": { "type": "string", "description": "vault entry name (default: hostname, e.g. voz.vn)" },
                     "session": { "type": "string", "description": "optional session id" }
                 },
                 "required": ["username", "password"]


### PR DESCRIPTION
## What

Completes the login loop: after `login` fills + submits, lightbrowse now **probes for actual login success** and **auto-saves credentials to the encrypted vault**.

- **`login_success_probe`** (CDP): page left the login URL? logout link / user menu / avatar appeared? → `detected: true/false`
- **MCP `login`**: `save_vault` (default true) + `vault_name`; resolves `vault:<name>.<field>` refs for username AND password server-side (real secret typed + re-saved, never in context); waits 2.5s, probes, saves on success; returns `{login, probe, vault_saved}`
- **HTTP `/v1/login`**: same (AppState now carries the vault)
- **CLI `login`**: `--no-save`, `--vault-name`
- Vault entry name defaults to hostname (e.g. `voz.vn`); entry carries url + source tag

## Live verification

Local login form → submit → success page with logout link:
```
probe: detected=true, has_logout=true, on_login_page=false
vault_saved: "127.0.0.1"
vault get 127.0.0.1 → username/password round-trip OK
```

Next-session follow-up: CLI `login` should also resolve `vault:` refs (currently only MCP/HTTP do).