### PR TITLE
feat: auto-save runbook on detected login success (vault + runbook together)

### DIFF
--- a/crates/lightbrowse-cli/src/main.rs
+++ b/crates/lightbrowse-cli/src/main.rs
@@ -547,10 +547,22 @@ async fn main() -> lightbrowse_core::Result<()> {
                             },
                         )
                         .map_err(lightbrowse_core::Error::Parse)?;
+                    // Auto-save a replayable runbook of the login steps.
+                    let mut runbook_saved = serde_json::Value::Null;
+                    let trail = cdp.trail();
+                    if !trail.is_empty() {
+                        let steps_json = serde_json::to_string(&trail)
+                            .map_err(|e| lightbrowse_core::Error::Parse(format!("runbook serialize: {e}")))?;
+                        let rb_name = format!("login-{name}");
+                        if memory.save_runbook(&rb_name, cur_url, &steps_json).is_ok() {
+                            runbook_saved = json!(rb_name);
+                        }
+                    }
                     print_json(&json!({
                         "login": res,
                         "probe": probe,
                         "vault_saved": name,
+                        "runbook_saved": runbook_saved,
                     }));
                     return Ok(());
                 }

--- a/crates/lightbrowse-http/src/lib.rs
+++ b/crates/lightbrowse-http/src/lib.rs
@@ -899,6 +899,7 @@ async fn login_action(
         .await
         .map_err(ApiError::from)?;
     let mut saved = serde_json::Value::Null;
+    let mut runbook_saved = serde_json::Value::Null;
     let mut probe = serde_json::Value::Null;
     if res.get("ok").and_then(|v| v.as_bool()) == Some(true) && q.save_vault {
         tokio::time::sleep(std::time::Duration::from_millis(2500)).await;
@@ -927,10 +928,20 @@ async fn login_action(
                 };
                 vault.set(&name, entry).map_err(ApiError::internal)?;
                 saved = json!(name);
+                // Auto-save a replayable runbook of the login steps.
+                let trail = cdp.trail();
+                if !trail.is_empty() {
+                    let steps_json = serde_json::to_string(&trail)
+                        .map_err(|e| ApiError::internal(format!("runbook serialize: {e}")))?;
+                    let rb_name = format!("login-{name}");
+                    if state.memory.save_runbook(&rb_name, url, &steps_json).is_ok() {
+                        runbook_saved = json!(rb_name);
+                    }
+                }
             }
         }
     }
-    Ok(Json(json!({ "login": res, "probe": probe, "vault_saved": saved })).into_response())
+    Ok(Json(json!({ "login": res, "probe": probe, "vault_saved": saved, "runbook_saved": runbook_saved })).into_response())
 }
 
 #[derive(Deserialize)]

--- a/crates/lightbrowse-mcp/src/lib.rs
+++ b/crates/lightbrowse-mcp/src/lib.rs
@@ -817,6 +817,7 @@ impl McpServer {
 
                 // Auto-save on detected success.
                 let mut saved = json!(null);
+                let mut runbook_saved = json!(null);
                 let mut probe = json!(null);
                 if save_vault {
                     tokio::time::sleep(std::time::Duration::from_millis(2500)).await;
@@ -854,6 +855,21 @@ impl McpServer {
                         } else {
                             return Err("vault unavailable — start with a vault path".into());
                         }
+                        // Auto-save a replayable runbook of the login steps.
+                        let trail = cdp.trail();
+                        if !trail.is_empty() {
+                            if let Some(m) = &s.memory {
+                                let steps_json = serde_json::to_string(&trail)
+                                    .map_err(|e| e.to_string())?;
+                                let rb_name = format!("login-{name}");
+                                if m
+                                    .save_runbook(&rb_name, url, &steps_json)
+                                    .is_ok()
+                                {
+                                    runbook_saved = json!(rb_name);
+                                }
+                            }
+                        }
                     }
                 }
 
@@ -861,6 +877,7 @@ impl McpServer {
                     "login": res,
                     "probe": probe,
                     "vault_saved": saved,
+                    "runbook_saved": runbook_saved,
                 })))
             }
             "fill_form" => {


### PR DESCRIPTION
## What

Completes the auto-persist loop: on detected login success, lightbrowse now saves BOTH the encrypted vault entry AND a replayable runbook of the exact steps (click/type/press trail from fill_login).

- `runbook_saved: "login-<hostname>"` alongside `vault_saved: "<hostname>"`
- MCP login / HTTP /v1/login / CLI login all save both
- Replay via `runbook/run login-<hostname>` with vault refs — credentials never in context

## Live verification

```
login fill: True | submitted: Enter
probe: detected=true
vault_saved: 127.0.0.1
runbook_saved: login-127.0.0.1
# memory.db: runbooks -> (login-127.0.0.1, 611 bytes of steps)
```

clippy clean, 13 suites pass. Backlog: #48 site whitelist for auto-save.