### PR TITLE
fix: fill_form submit detection — add sign-in/continue/next labels

### DIFF
--- a/crates/lightbrowse-cdp/src/lib.rs
+++ b/crates/lightbrowse-cdp/src/lib.rs
@@ -1464,7 +1464,7 @@ impl CdpBackend {
         let submitted = if submit {
             let sub_js = r#"(() => {
   const btn = Array.from(document.querySelectorAll('button[type=submit], input[type=submit], button'))
-    .find(b => /submit|login|register|sign\s*up|create|save|đăng ký|đăng nhập|đồng ý|tiếp tục|gửi/i.test((b.textContent || b.value || '')));
+    .find(b => /submit|login|log\s*in|sign\s*in|sign\s*up|register|create|save|continue|next|đăng ký|đăng nhập|đồng ý|tiếp tục|gửi/i.test((b.textContent || b.value || '')));
   if (btn) { btn.click(); return 'click:' + (btn.textContent || btn.value || '').trim().slice(0, 30); }
   return null;
 })()"#;


### PR DESCRIPTION
## What

Slack signin: the email-step submit button is "Sign In With Email" — didn't match the submit regex (only sign-up/login), so the Enter fallback fired and Slack's JS flow never started. Now the real button is clicked.

- regex: + log\s*in, sign\s*in, continue, next
- Verified live: `submitted=click:Sign In With Email`

## Known limitation (Slack)

The signin auth POST still stalls on "loading" in automated Chrome (even with the real profile + UA 149) — Slack bot-detects the signin endpoint itself. Real login needs a genuine browser session; the existing slack-reader flow (export xoxc token from a real logged-in browser) is the reliable path.